### PR TITLE
Shape, hasFace ...

### DIFF
--- a/ontology/ontology.161114.rdf
+++ b/ontology/ontology.161114.rdf
@@ -1,0 +1,1201 @@
+<?xml version="1.0"?>
+
+
+<!DOCTYPE rdf:RDF [
+    <!ENTITY owl "http://www.w3.org/2002/07/owl#" >
+    <!ENTITY xsd "http://www.w3.org/2001/XMLSchema#" >
+    <!ENTITY xml "http://www.w3.org/XML/1998/namespace" >
+    <!ENTITY skos "http://www.w3.org/2004/02/skos/core#" >
+    <!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#" >
+    <!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#" >
+]>
+
+
+<rdf:RDF xmlns="http://nomisma.org/ontology#"
+     xml:base="http://nomisma.org/ontology"
+     xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+     xmlns:owl="http://www.w3.org/2002/07/owl#"
+     xmlns:xml="http://www.w3.org/XML/1998/namespace"
+     xmlns:xsd="http://www.w3.org/2001/XMLSchema#"
+     xmlns:skos="http://www.w3.org/2004/02/skos/core#"
+     xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">
+    <owl:Ontology rdf:about="http://nomisma.org/ontology#">
+        <skos:definition rdf:datatype="&xsd;string">Nomisma.org is a collaborative project to provide stable digital representations of numismatic concepts according to the principles of Linked Open Data. These take the form of http URIs that also provide access to reusable information about those concepts, along with links to other resources.</skos:definition>
+    </owl:Ontology>
+    
+
+
+    <!-- 
+    ///////////////////////////////////////////////////////////////////////////////////////
+    //
+    // Annotation properties
+    //
+    ///////////////////////////////////////////////////////////////////////////////////////
+     -->
+
+    
+
+
+    <!-- http://www.w3.org/2004/02/skos/core#definition -->
+
+    <owl:AnnotationProperty rdf:about="&skos;definition"/>
+    
+
+
+    <!-- 
+    ///////////////////////////////////////////////////////////////////////////////////////
+    //
+    // Object Properties
+    //
+    ///////////////////////////////////////////////////////////////////////////////////////
+     -->
+
+    
+
+
+    <!-- http://nomisma.org/ontology#hasAppearance -->
+
+    <owl:ObjectProperty rdf:about="http://nomisma.org/ontology#hasAppearance">
+        <rdfs:label>hasAppearance</rdfs:label>
+        <skos:definition rdf:datatype="&xsd;string">Describes the appearance of a numismatic object. Eg. Iconography, legends and physical characteristics.</skos:definition>
+    </owl:ObjectProperty>
+    
+
+
+    <!-- http://nomisma.org/ontology#hasAuthority -->
+
+    <owl:ObjectProperty rdf:about="http://nomisma.org/ontology#hasAuthority">
+        <rdfs:label>hasAuthority</rdfs:label>
+        <skos:definition rdf:datatype="&xsd;string">Identifies the authority in whose name (explicitly or implicitly) a numismatic object was issued. Eg. Charlemagne, Augustus, Sparta, Federal Republic of Germany, Bank of England</skos:definition>
+    </owl:ObjectProperty>
+    
+
+
+    <!-- http://nomisma.org/ontology#hasAxis -->
+
+    <owl:ObjectProperty rdf:about="http://nomisma.org/ontology#hasAxis">
+        <rdfs:label>hasAxis</rdfs:label>
+        <skos:definition rdf:datatype="&xsd;string">Describes the directional relationship between the obverse and reverse of a numismatic object.</skos:definition>
+    </owl:ObjectProperty>
+    
+
+
+    <!-- http://nomisma.org/ontology#hasBearsDate -->
+
+    <owl:ObjectProperty rdf:about="http://nomisma.org/ontology#hasBearsDate">
+        <rdfs:label>hasBearsDate</rdfs:label>
+        <skos:definition rdf:datatype="&xsd;string">Describes a date that appears on an object</skos:definition>
+        <rdfs:subPropertyOf rdf:resource="http://nomisma.org/ontology#hasAppearance"/>
+    </owl:ObjectProperty>
+    
+
+
+    <!-- http://nomisma.org/ontology#hasCollection -->
+
+    <owl:ObjectProperty rdf:about="http://nomisma.org/ontology#hasCollection">
+        <rdfs:label>hasCollection</rdfs:label>
+        <skos:definition rdf:datatype="&xsd;string">Identifies the modern collection or repository in which a coin resides or has resided in the past. Collections are defined by Nomisma IDs</skos:definition>
+    </owl:ObjectProperty>
+    
+
+
+    <!-- http://nomisma.org/ontology#hasContext -->
+
+    <owl:ObjectProperty rdf:about="http://nomisma.org/ontology#hasContext">
+        <rdfs:label rdf:datatype="&xsd;string">hasContext</rdfs:label>
+        <skos:definition rdf:datatype="&xsd;string">Describes the context of a numismatic object.</skos:definition>
+    </owl:ObjectProperty>
+    
+
+
+    <!-- http://nomisma.org/ontology#hasControlmark -->
+
+    <owl:ObjectProperty rdf:about="http://nomisma.org/ontology#hasControlmark">
+        <rdfs:label>hasControlmark</rdfs:label>
+        <skos:definition rdf:datatype="&xsd;string">Identifies a letter, symbol or an inscription on an object intended to distinguish it as part of a group of coins within an issue or series.</skos:definition>
+        <rdfs:subPropertyOf rdf:resource="http://nomisma.org/ontology#hasPeculiarityOfProduction"/>
+    </owl:ObjectProperty>
+    
+
+
+    <!-- http://nomisma.org/ontology#hasCorrosion -->
+
+    <owl:ObjectProperty rdf:about="http://nomisma.org/ontology#hasCorrosion">
+        <rdfs:label>hasCorrosion</rdfs:label>
+        <skos:definition rdf:datatype="&xsd;string">Describes degradation due to chemical reaction with an environment, commonly in terms prescribed by &quot;Abnutzung und Korrosion: Bestimmmungstafeln zur Bearbeitung von Fundmünzen = Usure et corrosion. (1995). Lausanne.&quot; (OCLC 174260520)</skos:definition>
+    </owl:ObjectProperty>
+    
+
+
+    <!-- http://nomisma.org/ontology#hasCountermark -->
+
+    <owl:ObjectProperty rdf:about="http://nomisma.org/ontology#hasCountermark">
+        <rdfs:label>hasCountermark</rdfs:label>
+        <skos:definition rdf:datatype="&xsd;string">Identifies a mark or symbol punched into an object at some point during its time in circulation.</skos:definition>
+        <rdfs:subPropertyOf rdf:resource="http://nomisma.org/ontology#hasIconography"/>
+        <rdfs:subPropertyOf rdf:resource="http://nomisma.org/ontology#hasSecondaryTreatment"/>
+    </owl:ObjectProperty>
+    
+
+
+    <!-- http://nomisma.org/ontology#hasDate -->
+
+    <owl:ObjectProperty rdf:about="http://nomisma.org/ontology#hasDate">
+        <rdfs:label>hasDate</rdfs:label>
+        <skos:definition rdf:datatype="&xsd;string">Describes date (range) assigned in a numismatic context.</skos:definition>
+    </owl:ObjectProperty>
+    
+
+
+    <!-- http://nomisma.org/ontology#hasDenomination -->
+
+    <owl:ObjectProperty rdf:about="http://nomisma.org/ontology#hasDenomination">
+        <rdfs:label>hasDenomination</rdfs:label>
+        <skos:definition rdf:datatype="&xsd;string">Describes the monetary value assigned to an object within a denominational system. Examples: tetradrachm, chalkous, denarius.</skos:definition>
+    </owl:ObjectProperty>
+    
+
+
+    <!-- http://nomisma.org/ontology#hasDepth -->
+
+    <owl:ObjectProperty rdf:about="http://nomisma.org/ontology#hasDepth">
+        <rdfs:label>hasDepth</rdfs:label>
+        <skos:definition rdf:datatype="&xsd;string">Describes the depth of an object.</skos:definition>
+    </owl:ObjectProperty>
+    
+
+
+    <!-- http://nomisma.org/ontology#hasDiameter -->
+
+    <owl:ObjectProperty rdf:about="http://nomisma.org/ontology#hasDiameter">
+        <rdfs:label>hasDiameter</rdfs:label>
+        <skos:definition rdf:datatype="&xsd;string">Describes diameter of an object.</skos:definition>
+    </owl:ObjectProperty>
+    
+
+
+    <!-- http://nomisma.org/ontology#hasDie -->
+
+    <owl:ObjectProperty rdf:about="http://nomisma.org/ontology#hasDie">
+        <rdfs:label>hasDie</rdfs:label>
+        <skos:definition rdf:datatype="&xsd;string">Describes the die from which a numismatic object has been produced.</skos:definition>
+        <rdfs:subPropertyOf rdf:resource="http://nomisma.org/ontology#hasProductionObject"/>
+    </owl:ObjectProperty>
+    
+
+
+    <!-- http://nomisma.org/ontology#hasEdge -->
+
+    <owl:ObjectProperty rdf:about="http://nomisma.org/ontology#hasEdge">
+        <rdfs:label>hasEdge</rdfs:label>
+        <skos:definition rdf:datatype="&xsd;string">Describes characteristics of the edge of a numismatic object.</skos:definition>
+        <rdfs:subPropertyOf rdf:resource="http://nomisma.org/ontology#hasAppearance"/>
+    </owl:ObjectProperty>
+    
+
+
+    <!-- http://nomisma.org/ontology#hasEndDate -->
+
+    <owl:ObjectProperty rdf:about="http://nomisma.org/ontology#hasEndDate">
+        <rdfs:label>hasEndDate</rdfs:label>
+        <skos:definition rdf:datatype="&xsd;string">Identifies the final date in a range assigned in a numismatic context.</skos:definition>
+        <rdfs:subPropertyOf rdf:resource="&owl;topObjectProperty"/>
+    </owl:ObjectProperty>
+    
+
+
+    <!-- http://nomisma.org/ontology#hasFace -->
+
+    <owl:ObjectProperty rdf:about="http://nomisma.org/ontology#hasFace">
+        <rdfs:label>hasFace</rdfs:label>
+        <skos:definition rdf:datatype="&xsd;string">Identifies a particular face of a numismatic object. Where possible and appropriate, the more specific properties hasObverse or hasReverse are preferred.</skos:definition>
+        <rdfs:subPropertyOf rdf:resource="http://nomisma.org/ontology#hasAppearance"/>
+    </owl:ObjectProperty>
+    
+
+
+    <!-- http://nomisma.org/ontology#hasFindType -->
+
+    <owl:ObjectProperty rdf:about="http://nomisma.org/ontology#hasFindType">
+        <rdfs:label>hasFindType</rdfs:label>
+        <skos:definition rdf:datatype="&xsd;string">Describes the nature of and archaeological or other find. E.g. hoard, ritual deposit, single find, find in survey.</skos:definition>
+        <owl:deprecated rdf:datatype="&xsd;string">deprecated - please use nmo:hasContext instead, together with the class Context or its sub classes: Find, DepositionType and DiscoveryType</owl:deprecated>
+    </owl:ObjectProperty>
+    
+
+
+    <!-- http://nomisma.org/ontology#hasFindspot -->
+
+    <owl:ObjectProperty rdf:about="http://nomisma.org/ontology#hasFindspot">
+        <rdfs:label>hasFindspot</rdfs:label>
+        <skos:definition rdf:datatype="&xsd;string">Describes the location of the discovery of an object, whether by accident or in archaeological excavation.</skos:definition>
+        <rdfs:subPropertyOf rdf:resource="&owl;topObjectProperty"/>
+    </owl:ObjectProperty>
+    
+
+
+    <!-- http://nomisma.org/ontology#hasHeight -->
+
+    <owl:ObjectProperty rdf:about="http://nomisma.org/ontology#hasHeight">
+        <rdfs:label>hasHeight</rdfs:label>
+        <skos:definition rdf:datatype="&xsd;string">Describes the height of a numismatic object.</skos:definition>
+    </owl:ObjectProperty>
+    
+
+
+    <!-- http://nomisma.org/ontology#hasIconography -->
+
+    <owl:ObjectProperty rdf:about="http://nomisma.org/ontology#hasIconography">
+        <rdfs:label>hasIconography</rdfs:label>
+        <skos:definition rdf:datatype="&xsd;string">Describes an iconography placed on a numismatic object.</skos:definition>
+        <rdfs:subPropertyOf rdf:resource="http://nomisma.org/ontology#hasAppearance"/>
+    </owl:ObjectProperty>
+    
+
+
+    <!-- http://nomisma.org/ontology#hasIssuer -->
+
+    <owl:ObjectProperty rdf:about="http://nomisma.org/ontology#hasIssuer">
+        <rdfs:label>hasIssuer</rdfs:label>
+        <skos:definition rdf:datatype="&xsd;string">Identifies the person administratively responsible for the issue of a numismatic object, generally named in some capacity on the object.</skos:definition>
+    </owl:ObjectProperty>
+    
+
+
+    <!-- http://nomisma.org/ontology#hasLegend -->
+
+    <owl:ObjectProperty rdf:about="http://nomisma.org/ontology#hasLegend">
+        <rdfs:label>hasLegend</rdfs:label>
+        <skos:definition rdf:datatype="&xsd;string">Describes the inscription or printing placed on a numismatic object as part of the production process.</skos:definition>
+        <rdfs:subPropertyOf rdf:resource="http://nomisma.org/ontology#hasAppearance"/>
+    </owl:ObjectProperty>
+    
+
+
+    <!-- http://nomisma.org/ontology#hasManufacture -->
+
+    <owl:ObjectProperty rdf:about="http://nomisma.org/ontology#hasManufacture">
+        <rdfs:label>hasManufacture</rdfs:label>
+        <skos:definition rdf:datatype="&xsd;string">Describes the method of manufacture of a numismatic object. Eg. struck, cast, printed</skos:definition>
+    </owl:ObjectProperty>
+    
+
+
+    <!-- http://nomisma.org/ontology#hasMaterial -->
+
+    <owl:ObjectProperty rdf:about="http://nomisma.org/ontology#hasMaterial">
+        <rdfs:label>hasMaterial</rdfs:label>
+        <skos:definition rdf:datatype="&xsd;string">Describes the physical material from which a numismatic object is made.</skos:definition>
+    </owl:ObjectProperty>
+    
+
+
+    <!-- http://nomisma.org/ontology#hasMaxDepth -->
+
+    <owl:ObjectProperty rdf:about="http://nomisma.org/ontology#hasMaxDepth">
+        <rdfs:label>hasMaxDepth</rdfs:label>
+        <skos:definition rdf:datatype="&xsd;string">Describes the maximum depth of a numismatic object.</skos:definition>
+        <rdfs:subPropertyOf rdf:resource="http://nomisma.org/ontology#hasDepth"/>
+    </owl:ObjectProperty>
+    
+
+
+    <!-- http://nomisma.org/ontology#hasMaxDiameter -->
+
+    <owl:ObjectProperty rdf:about="http://nomisma.org/ontology#hasMaxDiameter">
+        <rdfs:label>hasMaxDiameter</rdfs:label>
+        <skos:definition rdf:datatype="&xsd;string">Describes the maximum diameter of a numismatic object.</skos:definition>
+        <rdfs:subPropertyOf rdf:resource="http://nomisma.org/ontology#hasDiameter"/>
+    </owl:ObjectProperty>
+    
+
+
+    <!-- http://nomisma.org/ontology#hasMaxHeight -->
+
+    <owl:ObjectProperty rdf:about="http://nomisma.org/ontology#hasMaxHeight">
+        <rdfs:label>hasMaxHeight</rdfs:label>
+        <skos:definition rdf:datatype="&xsd;string">Describes the maximum height of a numismatic object.</skos:definition>
+        <rdfs:subPropertyOf rdf:resource="http://nomisma.org/ontology#hasHeight"/>
+    </owl:ObjectProperty>
+    
+
+
+    <!-- http://nomisma.org/ontology#hasMaxWidth -->
+
+    <owl:ObjectProperty rdf:about="http://nomisma.org/ontology#hasMaxWidth">
+        <rdfs:label>hasMaxWidth</rdfs:label>
+        <skos:definition rdf:datatype="&xsd;string">Describes the maximum width of a numismatic object.</skos:definition>
+        <rdfs:subPropertyOf rdf:resource="http://nomisma.org/ontology#hasWidth"/>
+    </owl:ObjectProperty>
+    
+
+
+    <!-- http://nomisma.org/ontology#hasMinDepth -->
+
+    <owl:ObjectProperty rdf:about="http://nomisma.org/ontology#hasMinDepth">
+        <rdfs:label>hasMinDepth</rdfs:label>
+        <skos:definition rdf:datatype="&xsd;string">Describes the minimum depth of a numismatic object.</skos:definition>
+        <rdfs:subPropertyOf rdf:resource="http://nomisma.org/ontology#hasDepth"/>
+    </owl:ObjectProperty>
+    
+
+
+    <!-- http://nomisma.org/ontology#hasMinDiameter -->
+
+    <owl:ObjectProperty rdf:about="http://nomisma.org/ontology#hasMinDiameter">
+        <rdfs:label>hasMinDiameter</rdfs:label>
+        <skos:definition rdf:datatype="&xsd;string">Describes the minimum diameter of a numismatic object.</skos:definition>
+        <rdfs:subPropertyOf rdf:resource="http://nomisma.org/ontology#hasDiameter"/>
+    </owl:ObjectProperty>
+    
+
+
+    <!-- http://nomisma.org/ontology#hasMinHeight -->
+
+    <owl:ObjectProperty rdf:about="http://nomisma.org/ontology#hasMinHeight">
+        <rdfs:label>hasMinHeight</rdfs:label>
+        <skos:definition rdf:datatype="&xsd;string">Describes the minimum height of a numismatic object.</skos:definition>
+        <rdfs:subPropertyOf rdf:resource="http://nomisma.org/ontology#hasHeight"/>
+    </owl:ObjectProperty>
+    
+
+
+    <!-- http://nomisma.org/ontology#hasMinWidth -->
+
+    <owl:ObjectProperty rdf:about="http://nomisma.org/ontology#hasMinWidth">
+        <rdfs:label>hasMinWidth</rdfs:label>
+        <skos:definition rdf:datatype="&xsd;string">Describes the minimum width of a numismatic object.</skos:definition>
+        <rdfs:subPropertyOf rdf:resource="http://nomisma.org/ontology#hasWidth"/>
+    </owl:ObjectProperty>
+    
+
+
+    <!-- http://nomisma.org/ontology#hasMint -->
+
+    <owl:ObjectProperty rdf:about="http://nomisma.org/ontology#hasMint">
+        <rdfs:label>hasMint</rdfs:label>
+        <skos:definition rdf:datatype="&xsd;string">Identifies the place of manufacture or issue of a numismatic object.</skos:definition>
+    </owl:ObjectProperty>
+    
+
+
+    <!-- http://nomisma.org/ontology#hasMintmark -->
+
+    <owl:ObjectProperty rdf:about="http://nomisma.org/ontology#hasMintmark">
+        <rdfs:label>hasMintmark</rdfs:label>
+        <skos:definition rdf:datatype="&xsd;string">Identifies the letter, symbol or an inscription on a numismatic object indicating the mint where it was produced.</skos:definition>
+        <rdfs:subPropertyOf rdf:resource="http://nomisma.org/ontology#hasControlmark"/>
+        <rdfs:subPropertyOf rdf:resource="http://nomisma.org/ontology#hasIconography"/>
+    </owl:ObjectProperty>
+    
+
+
+    <!-- http://nomisma.org/ontology#hasMonogram -->
+
+    <owl:ObjectProperty rdf:about="http://nomisma.org/ontology#hasMonogram">
+        <rdfs:label>hasMonogram</rdfs:label>
+        <skos:definition rdf:datatype="&xsd;string">Identifies the monogram that appears on a numismatic object.</skos:definition>
+        <rdfs:subPropertyOf rdf:resource="http://nomisma.org/ontology#hasIconography"/>
+    </owl:ObjectProperty>
+    
+
+
+    <!-- http://nomisma.org/ontology#hasObjectType -->
+
+    <owl:ObjectProperty rdf:about="http://nomisma.org/ontology#hasObjectType">
+        <rdfs:label>hasObjectType</rdfs:label>
+        <skos:definition rdf:datatype="&xsd;string">Identifies the type of numismatic object. E.g. Coin, token, banknote.</skos:definition>
+    </owl:ObjectProperty>
+    
+
+
+    <!-- http://nomisma.org/ontology#hasObverse -->
+
+    <owl:ObjectProperty rdf:about="http://nomisma.org/ontology#hasObverse">
+        <rdfs:label>hasObverse</rdfs:label>
+        <skos:definition rdf:datatype="&xsd;string">Identifies a particular face of a numismatic object. Normally it will be the face carrying the represenation, badge or inscription of the issuing authority. In ancient, hand-struck coinage it is generally the lower (anvil) die. In English often known as &quot;heads&quot;.</skos:definition>
+        <rdfs:subPropertyOf rdf:resource="http://nomisma.org/ontology#hasFace"/>
+    </owl:ObjectProperty>
+    
+
+
+    <!-- http://nomisma.org/ontology#hasPeculiarity -->
+
+    <owl:ObjectProperty rdf:about="http://nomisma.org/ontology#hasPeculiarity">
+        <rdfs:label>hasPeculiarity</rdfs:label>
+        <skos:definition rdf:datatype="&xsd;string">Describes a feature of an individual numismatic object that marks it out from other objects of the same type. Can a result of production, such as plating, or post-production activity, such as piercing, cutting or mounting.</skos:definition>
+    </owl:ObjectProperty>
+    
+
+
+    <!-- http://nomisma.org/ontology#hasPeculiarityOfProduction -->
+
+    <owl:ObjectProperty rdf:about="http://nomisma.org/ontology#hasPeculiarityOfProduction">
+        <rdfs:label>hasPeculiarityOfProduction</rdfs:label>
+        <skos:definition rdf:datatype="&xsd;string">Describes anomalies or unusual features which are related to the process of production of a numismatic object; for example serratus, plating, doublestrike, etc.</skos:definition>
+        <rdfs:subPropertyOf rdf:resource="http://nomisma.org/ontology#hasPeculiarity"/>
+    </owl:ObjectProperty>
+    
+
+
+    <!-- http://nomisma.org/ontology#hasPortrait -->
+
+    <owl:ObjectProperty rdf:about="http://nomisma.org/ontology#hasPortrait">
+        <rdfs:label>hasPortrait</rdfs:label>
+        <skos:definition rdf:datatype="&xsd;string">Identifies the person whose portrait appears on a numismatic object.</skos:definition>
+        <rdfs:subPropertyOf rdf:resource="http://nomisma.org/ontology#hasIconography"/>
+    </owl:ObjectProperty>
+    
+
+
+    <!-- http://nomisma.org/ontology#hasProductionDate -->
+
+    <owl:ObjectProperty rdf:about="http://nomisma.org/ontology#hasProductionDate">
+        <rdfs:label>hasProductionDate</rdfs:label>
+        <skos:definition rdf:datatype="&xsd;string">Describes the date (range) of the production of a numismatic object.</skos:definition>
+        <rdfs:subPropertyOf rdf:resource="http://nomisma.org/ontology#hasDate"/>
+    </owl:ObjectProperty>
+    
+
+
+    <!-- http://nomisma.org/ontology#hasProductionObject -->
+
+    <owl:ObjectProperty rdf:about="http://nomisma.org/ontology#hasProductionObject">
+        <rdfs:label>hasProductionObject</rdfs:label>
+        <skos:definition rdf:datatype="&xsd;string"></skos:definition>
+    </owl:ObjectProperty>
+    
+
+
+    <!-- http://nomisma.org/ontology#hasReferenceWork -->
+
+    <owl:ObjectProperty rdf:about="http://nomisma.org/ontology#hasReferenceWork">
+        <rdfs:label>hasReferenceWork</rdfs:label>
+        <skos:definition rdf:datatype="&xsd;string">Specifies a published work of reference relevant to a numismatic object.</skos:definition>
+    </owl:ObjectProperty>
+    
+
+
+    <!-- http://nomisma.org/ontology#hasReverse -->
+
+    <owl:ObjectProperty rdf:about="http://nomisma.org/ontology#hasReverse">
+        <rdfs:label>hasReverse</rdfs:label>
+        <skos:definition rdf:datatype="&xsd;string">Identifies a the face of a numismatic object opposed to the obverse. In ancient, hand-struck coinage it is generally the upper die. In English often known as &quot;tails&quot;.</skos:definition>
+        <rdfs:subPropertyOf rdf:resource="http://nomisma.org/ontology#hasFace"/>
+    </owl:ObjectProperty>
+    
+
+
+    <!-- http://nomisma.org/ontology#hasSecondaryTreatment -->
+
+    <owl:ObjectProperty rdf:about="http://nomisma.org/ontology#hasSecondaryTreatment">
+        <rdfs:label>hasSecondaryTreatment</rdfs:label>
+        <skos:definition rdf:datatype="&xsd;string">Describes anomalies or unusual features which arise subsequent to the actual production of a coin; for example halving, chop-marking, etc.</skos:definition>
+        <rdfs:subPropertyOf rdf:resource="http://nomisma.org/ontology#hasPeculiarity"/>
+    </owl:ObjectProperty>
+    
+
+
+    <!-- http://nomisma.org/ontology#hasShape -->
+
+    <owl:ObjectProperty rdf:about="http://nomisma.org/ontology#hasShape">
+        <rdfs:label rdf:datatype="&xsd;string">hasShape</rdfs:label>
+        <skos:definition rdf:datatype="&xsd;string">Describes the shape of a numismatic object.</skos:definition>
+    </owl:ObjectProperty>
+    
+
+
+    <!-- http://nomisma.org/ontology#hasStartDate -->
+
+    <owl:ObjectProperty rdf:about="http://nomisma.org/ontology#hasStartDate">
+        <rdfs:label>hasStartDate</rdfs:label>
+        <skos:definition rdf:datatype="&xsd;string">Identifies the initial date in a range assigned in a numismatic context.</skos:definition>
+        <rdfs:subPropertyOf rdf:resource="&owl;topObjectProperty"/>
+    </owl:ObjectProperty>
+    
+
+
+    <!-- http://nomisma.org/ontology#hasStatedAuthority -->
+
+    <owl:ObjectProperty rdf:about="http://nomisma.org/ontology#hasStatedAuthority">
+        <rdfs:label>hasStatedAuthority</rdfs:label>
+        <skos:definition rdf:datatype="&xsd;string">The authority as stated on a numismatic object. This may, but need not, be the same as the real authority behind the object (expressed separately as hasAuthority).</skos:definition>
+    </owl:ObjectProperty>
+    
+
+
+    <!-- http://nomisma.org/ontology#hasTypeSeriesItem -->
+
+    <owl:ObjectProperty rdf:about="http://nomisma.org/ontology#hasTypeSeriesItem">
+        <rdfs:label>hasTypeSeriesItem</rdfs:label>
+        <skos:definition rdf:datatype="&xsd;string">Identifies the position of a numismatic object within a published or recognized reference list of coin types, such as a catalogue or corpus.</skos:definition>
+    </owl:ObjectProperty>
+    
+
+
+    <!-- http://nomisma.org/ontology#hasWear -->
+
+    <owl:ObjectProperty rdf:about="http://nomisma.org/ontology#hasWear">
+        <rdfs:label>hasWear</rdfs:label>
+        <skos:definition rdf:datatype="&xsd;string">Describes wear visible on a numismatic object due to use or circulation, commonly in terms prescribed by &quot;Abnutzung und Korrosion: Bestimmmungstafeln zur Bearbeitung von Fundmünzen = Usure et corrosion. (1995). Lausanne.&quot; (OCLC 174260520)</skos:definition>
+    </owl:ObjectProperty>
+    
+
+
+    <!-- http://nomisma.org/ontology#hasWeight -->
+
+    <owl:ObjectProperty rdf:about="http://nomisma.org/ontology#hasWeight">
+        <rdfs:label>hasWeight</rdfs:label>
+        <skos:definition rdf:datatype="&xsd;string">Describes the actual weight of a numismatic object.</skos:definition>
+    </owl:ObjectProperty>
+    
+
+
+    <!-- http://nomisma.org/ontology#hasWeightStandard -->
+
+    <owl:ObjectProperty rdf:about="http://nomisma.org/ontology#hasWeightStandard">
+        <rdfs:label>hasWeightStandard</rdfs:label>
+        <skos:definition rdf:datatype="&xsd;string">Describes the conventional weight system according to which a numismatic object of intrinsic value was produced.</skos:definition>
+    </owl:ObjectProperty>
+    
+
+
+    <!-- http://nomisma.org/ontology#hasWidth -->
+
+    <owl:ObjectProperty rdf:about="http://nomisma.org/ontology#hasWidth">
+        <rdfs:label>hasWidth</rdfs:label>
+        <skos:definition rdf:datatype="&xsd;string">Describes the width of a numismatic object.</skos:definition>
+        <rdfs:subPropertyOf rdf:resource="&owl;topObjectProperty"/>
+    </owl:ObjectProperty>
+    
+
+
+    <!-- http://nomisma.org/ontology#representsObjectType -->
+
+    <owl:ObjectProperty rdf:about="http://nomisma.org/ontology#representsObjectType">
+        <rdfs:label>representsObjectType</rdfs:label>
+        <skos:definition rdf:datatype="&xsd;string">To indicate what kind of object type is represented by (for example) an type series item (a coin, banknote, token, ...).</skos:definition>
+    </owl:ObjectProperty>
+    
+
+
+    <!-- 
+    ///////////////////////////////////////////////////////////////////////////////////////
+    //
+    // Classes
+    //
+    ///////////////////////////////////////////////////////////////////////////////////////
+     -->
+
+    
+
+
+    <!-- http://nomisma.org/ontology#CoinWear -->
+
+    <owl:Class rdf:about="http://nomisma.org/ontology#CoinWear">
+        <rdfs:subClassOf rdf:resource="http://nomisma.org/ontology#Wear"/>
+    </owl:Class>
+    
+
+
+    <!-- http://nomisma.org/ontology#Collection -->
+
+    <owl:Class rdf:about="http://nomisma.org/ontology#Collection"/>
+    
+
+
+    <!-- http://nomisma.org/ontology#Context -->
+
+    <owl:Class rdf:about="http://nomisma.org/ontology#Context">
+        <rdfs:label>Context</rdfs:label>
+        <skos:definition rdf:datatype="&xsd;string">The archaeological context of a numismatic object. </skos:definition>
+    </owl:Class>
+    
+
+
+    <!-- http://nomisma.org/ontology#Controlmark -->
+
+    <owl:Class rdf:about="http://nomisma.org/ontology#Controlmark">
+        <rdfs:label>Controlmark</rdfs:label>
+        <skos:definition rdf:datatype="&xsd;string">A control mark is a letter, symbol or an inscription on a coin intended to distinguish a group of coins within an issue or series.</skos:definition>
+    </owl:Class>
+    
+
+
+    <!-- http://nomisma.org/ontology#Corrosion -->
+
+    <owl:Class rdf:about="http://nomisma.org/ontology#Corrosion">
+        <rdfs:label>Corrosion</rdfs:label>
+        <skos:definition rdf:datatype="&xsd;string">Degradation to a numismatic object due to chemical reaction with its environment.</skos:definition>
+    </owl:Class>
+    
+
+
+    <!-- http://nomisma.org/ontology#Countermark -->
+
+    <owl:Class rdf:about="http://nomisma.org/ontology#Countermark">
+        <rdfs:label>Countermark</rdfs:label>
+        <rdfs:subClassOf rdf:resource="http://nomisma.org/ontology#SecondaryTreatment"/>
+        <skos:definition rdf:datatype="&xsd;string">A mark or symbol punched into a coin at some point during its time in circulation.</skos:definition>
+    </owl:Class>
+    
+
+
+    <!-- http://nomisma.org/ontology#Denomination -->
+
+    <owl:Class rdf:about="http://nomisma.org/ontology#Denomination"/>
+    
+
+
+    <!-- http://nomisma.org/ontology#DepositionType -->
+
+    <owl:Class rdf:about="http://nomisma.org/ontology#DepositionType">
+        <rdfs:label>DepositionType</rdfs:label>
+        <rdfs:subClassOf rdf:resource="http://nomisma.org/ontology#Context"/>
+        <skos:definition rdf:datatype="&xsd;string">The circumstances under which an object or group of objects came to be deposited and part of the archaeological record, for example as a hoard, votive deposit or chance loss.</skos:definition>
+    </owl:Class>
+    
+
+
+    <!-- http://nomisma.org/ontology#DieWear -->
+
+    <owl:Class rdf:about="http://nomisma.org/ontology#DieWear">
+        <rdfs:label>DieWear</rdfs:label>
+        <rdfs:subClassOf rdf:resource="http://nomisma.org/ontology#Wear"/>
+        <skos:definition rdf:datatype="&xsd;string">Wear on a die occurring as a result of its use.</skos:definition>
+    </owl:Class>
+    
+
+
+    <!-- http://nomisma.org/ontology#DiscoveryType -->
+
+    <owl:Class rdf:about="http://nomisma.org/ontology#DiscoveryType">
+        <rdfs:label>DiscoveryType</rdfs:label>
+        <rdfs:subClassOf rdf:resource="http://nomisma.org/ontology#Context"/>
+        <skos:definition rdf:datatype="&xsd;string">The circumstances under which an object or group of objects came to be discovered, for example as a chance stray find or a controlled excavation.</skos:definition>
+    </owl:Class>
+    
+
+
+    <!-- http://nomisma.org/ontology#Ethnic -->
+
+    <owl:Class rdf:about="http://nomisma.org/ontology#Ethnic"/>
+    
+
+
+    <!-- http://nomisma.org/ontology#FieldOfNumismatics -->
+
+    <owl:Class rdf:about="http://nomisma.org/ontology#FieldOfNumismatics"/>
+    
+
+
+    <!-- http://nomisma.org/ontology#Find -->
+
+    <owl:Class rdf:about="http://nomisma.org/ontology#Find">
+        <rdfs:label>Find</rdfs:label>
+        <rdfs:subClassOf rdf:resource="http://nomisma.org/ontology#Context"/>
+        <skos:definition rdf:datatype="&xsd;string">A numismatic object or group of numismatic objects that was lost or deposited, whether intentionally or unintentionally, in previous times, and subsequently recovered. The recovery takes place independently of any intention of retrieval associated with the original deposition.</skos:definition>
+    </owl:Class>
+    
+
+
+    <!-- http://nomisma.org/ontology#Manufacture -->
+
+    <owl:Class rdf:about="http://nomisma.org/ontology#Manufacture"/>
+    
+
+
+    <!-- http://nomisma.org/ontology#Material -->
+
+    <owl:Class rdf:about="http://nomisma.org/ontology#Material"/>
+    
+
+
+    <!-- http://nomisma.org/ontology#Mint -->
+
+    <owl:Class rdf:about="http://nomisma.org/ontology#Mint"/>
+    
+
+
+    <!-- http://nomisma.org/ontology#Mintmark -->
+
+    <owl:Class rdf:about="http://nomisma.org/ontology#Mintmark">
+        <rdfs:label>Mintmark</rdfs:label>
+        <rdfs:subClassOf rdf:resource="http://nomisma.org/ontology#Controlmark"/>
+        <skos:definition rdf:datatype="&xsd;string">A mint mark is a letter, symbol or an inscription on a coin indicating the mint where the coin was produced.</skos:definition>
+    </owl:Class>
+    
+
+
+    <!-- http://nomisma.org/ontology#Monogram -->
+
+    <owl:Class rdf:about="http://nomisma.org/ontology#Monogram">
+        <rdfs:label>Monogram</rdfs:label>
+        <skos:definition rdf:datatype="&xsd;string">A monogram is a symbol made by overlapping or combining of letters or other graphemes.</skos:definition>
+    </owl:Class>
+    
+
+
+    <!-- http://nomisma.org/ontology#NumismaticObject -->
+
+    <owl:Class rdf:about="http://nomisma.org/ontology#NumismaticObject">
+        <rdfs:label>NumismaticObject</rdfs:label>
+        <skos:definition rdf:datatype="&xsd;string">The physical objects that are of interest in the numismatic domain.</skos:definition>
+    </owl:Class>
+    
+
+
+    <!-- http://nomisma.org/ontology#NumismaticTerm -->
+
+    <owl:Class rdf:about="http://nomisma.org/ontology#NumismaticTerm">
+        <rdfs:label>NumismaticTerm</rdfs:label>
+        <skos:definition rdf:datatype="&xsd;string">A term used within the field of numismatics to describe or to otherwise convey information specific to the numismatic discipline, or to numismatic objects.</skos:definition>
+    </owl:Class>
+    
+
+
+    <!-- http://nomisma.org/ontology#ObjectType -->
+
+    <owl:Class rdf:about="http://nomisma.org/ontology#ObjectType"/>
+    
+
+
+    <!-- http://nomisma.org/ontology#Peculiarity -->
+
+    <owl:Class rdf:about="http://nomisma.org/ontology#Peculiarity">
+        <rdfs:label>Peculiarity</rdfs:label>
+        <skos:definition rdf:datatype="&xsd;string">A feature of a numismatic object that is not part of the original design. </skos:definition>
+    </owl:Class>
+    
+
+
+    <!-- http://nomisma.org/ontology#PeculiarityOfProduction -->
+
+    <owl:Class rdf:about="http://nomisma.org/ontology#PeculiarityOfProduction">
+        <rdfs:label>PeculiarityOfProduction</rdfs:label>
+        <rdfs:subClassOf rdf:resource="http://nomisma.org/ontology#Peculiarity"/>
+        <skos:definition rdf:datatype="&xsd;string">Anomalies or unusual features which are related to the process of production of a coin; for example serratus, plating, doublestrike, etc.</skos:definition>
+    </owl:Class>
+    
+
+
+    <!-- http://nomisma.org/ontology#ReferenceWork -->
+
+    <owl:Class rdf:about="http://nomisma.org/ontology#ReferenceWork"/>
+    
+
+
+    <!-- http://nomisma.org/ontology#Region -->
+
+    <owl:Class rdf:about="http://nomisma.org/ontology#Region"/>
+    
+
+
+    <!-- http://nomisma.org/ontology#SecondaryTreatment -->
+
+    <owl:Class rdf:about="http://nomisma.org/ontology#SecondaryTreatment">
+        <rdfs:label>SecondaryTreatment</rdfs:label>
+        <rdfs:subClassOf rdf:resource="http://nomisma.org/ontology#Peculiarity"/>
+        <skos:definition rdf:datatype="&xsd;string">Anomalies or unusual features which arise subsequent to the actual production of a coin; for example halving, chop-marking, etc.</skos:definition>
+    </owl:Class>
+    
+
+
+    <!-- http://nomisma.org/ontology#Shape -->
+
+    <owl:Class rdf:about="http://nomisma.org/ontology#Shape">
+        <rdfs:label>Shape</rdfs:label>
+        <skos:definition>The possible shapes numismatic objects might have, could be standard like round or rectangular or even a polygon.</skos:definition>
+    </owl:Class>
+    
+
+
+    <!-- http://nomisma.org/ontology#TypeSeries -->
+
+    <owl:Class rdf:about="http://nomisma.org/ontology#TypeSeries">
+        <rdfs:subClassOf rdf:resource="http://nomisma.org/ontology#ReferenceWork"/>
+    </owl:Class>
+    
+
+
+    <!-- http://nomisma.org/ontology#TypeSeriesItem -->
+
+    <owl:Class rdf:about="http://nomisma.org/ontology#TypeSeriesItem"/>
+    
+
+
+    <!-- http://nomisma.org/ontology#Wear -->
+
+    <owl:Class rdf:about="http://nomisma.org/ontology#Wear"/>
+    
+
+
+    <!-- http://nomisma.org/ontology#WeightStandard -->
+
+    <owl:Class rdf:about="http://nomisma.org/ontology#WeightStandard"/>
+    
+
+
+    <!-- 
+    ///////////////////////////////////////////////////////////////////////////////////////
+    //
+    // Individuals
+    //
+    ///////////////////////////////////////////////////////////////////////////////////////
+     -->
+
+    
+
+
+    <!-- http://nomisma.org/id/coin -->
+
+    <owl:NamedIndividual rdf:about="http://nomisma.org/id/coin">
+        <owl:sameAs rdf:resource="http://nomisma.org/ontology#Coin"/>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://nomisma.org/id/coin_wear -->
+
+    <owl:NamedIndividual rdf:about="http://nomisma.org/id/coin_wear">
+        <owl:sameAs rdf:resource="http://nomisma.org/ontology#CoinWear"/>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://nomisma.org/id/collection -->
+
+    <owl:NamedIndividual rdf:about="http://nomisma.org/id/collection">
+        <owl:sameAs rdf:resource="http://nomisma.org/ontology#Collection"/>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://nomisma.org/id/denomination -->
+
+    <owl:NamedIndividual rdf:about="http://nomisma.org/id/denomination">
+        <owl:sameAs rdf:resource="http://nomisma.org/ontology#Denomination"/>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://nomisma.org/id/ethnic -->
+
+    <owl:NamedIndividual rdf:about="http://nomisma.org/id/ethnic">
+        <owl:sameAs rdf:resource="http://nomisma.org/ontology#Ethnic"/>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://nomisma.org/id/field_of_numismatics -->
+
+    <owl:NamedIndividual rdf:about="http://nomisma.org/id/field_of_numismatics">
+        <owl:sameAs rdf:resource="http://nomisma.org/ontology#FieldOfNumismatics"/>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://nomisma.org/id/manufacture -->
+
+    <owl:NamedIndividual rdf:about="http://nomisma.org/id/manufacture">
+        <owl:sameAs rdf:resource="http://nomisma.org/ontology#Manufacture"/>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://nomisma.org/id/material -->
+
+    <owl:NamedIndividual rdf:about="http://nomisma.org/id/material">
+        <owl:sameAs rdf:resource="http://nomisma.org/ontology#Material"/>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://nomisma.org/id/medal -->
+
+    <owl:NamedIndividual rdf:about="http://nomisma.org/id/medal">
+        <owl:sameAs rdf:resource="http://nomisma.org/ontology#Medal"/>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://nomisma.org/id/mint -->
+
+    <owl:NamedIndividual rdf:about="http://nomisma.org/id/mint">
+        <owl:sameAs rdf:resource="http://nomisma.org/ontology#Mint"/>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://nomisma.org/id/object_type -->
+
+    <owl:NamedIndividual rdf:about="http://nomisma.org/id/object_type">
+        <owl:sameAs rdf:resource="http://nomisma.org/ontology#ObjectType"/>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://nomisma.org/id/reference_work -->
+
+    <owl:NamedIndividual rdf:about="http://nomisma.org/id/reference_work">
+        <owl:sameAs rdf:resource="http://nomisma.org/ontology#ReferenceWork"/>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://nomisma.org/id/region -->
+
+    <owl:NamedIndividual rdf:about="http://nomisma.org/id/region">
+        <owl:sameAs rdf:resource="http://nomisma.org/ontology#Region"/>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://nomisma.org/id/seal -->
+
+    <owl:NamedIndividual rdf:about="http://nomisma.org/id/seal">
+        <owl:sameAs rdf:resource="http://nomisma.org/ontology#Seal"/>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://nomisma.org/id/tessera -->
+
+    <owl:NamedIndividual rdf:about="http://nomisma.org/id/tessera">
+        <owl:sameAs rdf:resource="http://nomisma.org/ontology#Tessera"/>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://nomisma.org/id/token -->
+
+    <owl:NamedIndividual rdf:about="http://nomisma.org/id/token">
+        <owl:sameAs rdf:resource="http://nomisma.org/ontology#Token"/>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://nomisma.org/id/type_series -->
+
+    <owl:NamedIndividual rdf:about="http://nomisma.org/id/type_series">
+        <owl:sameAs rdf:resource="http://nomisma.org/ontology#TypeSeries"/>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://nomisma.org/id/type_series_item -->
+
+    <owl:NamedIndividual rdf:about="http://nomisma.org/id/type_series_item">
+        <owl:sameAs rdf:resource="http://nomisma.org/ontology#TypeSeriesItem"/>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://nomisma.org/id/weight_standard -->
+
+    <owl:NamedIndividual rdf:about="http://nomisma.org/id/weight_standard">
+        <owl:sameAs rdf:resource="http://nomisma.org/ontology#WeightStandard"/>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://nomisma.org/ontology#Coin -->
+
+    <owl:NamedIndividual rdf:about="http://nomisma.org/ontology#Coin"/>
+    
+
+
+    <!-- http://nomisma.org/ontology#CoinWear -->
+
+    <owl:NamedIndividual rdf:about="http://nomisma.org/ontology#CoinWear"/>
+    
+
+
+    <!-- http://nomisma.org/ontology#Collection -->
+
+    <owl:NamedIndividual rdf:about="http://nomisma.org/ontology#Collection"/>
+    
+
+
+    <!-- http://nomisma.org/ontology#Denomination -->
+
+    <owl:NamedIndividual rdf:about="http://nomisma.org/ontology#Denomination"/>
+    
+
+
+    <!-- http://nomisma.org/ontology#Ethnic -->
+
+    <owl:NamedIndividual rdf:about="http://nomisma.org/ontology#Ethnic"/>
+    
+
+
+    <!-- http://nomisma.org/ontology#FieldOfNumismatics -->
+
+    <owl:NamedIndividual rdf:about="http://nomisma.org/ontology#FieldOfNumismatics"/>
+    
+
+
+    <!-- http://nomisma.org/ontology#Manufacture -->
+
+    <owl:NamedIndividual rdf:about="http://nomisma.org/ontology#Manufacture"/>
+    
+
+
+    <!-- http://nomisma.org/ontology#Material -->
+
+    <owl:NamedIndividual rdf:about="http://nomisma.org/ontology#Material"/>
+    
+
+
+    <!-- http://nomisma.org/ontology#Medal -->
+
+    <owl:NamedIndividual rdf:about="http://nomisma.org/ontology#Medal"/>
+    
+
+
+    <!-- http://nomisma.org/ontology#Medallion -->
+
+    <owl:NamedIndividual rdf:about="http://nomisma.org/ontology#Medallion"/>
+    
+
+
+    <!-- http://nomisma.org/ontology#Mint -->
+
+    <owl:NamedIndividual rdf:about="http://nomisma.org/ontology#Mint"/>
+    
+
+
+    <!-- http://nomisma.org/ontology#ObjectType -->
+
+    <owl:NamedIndividual rdf:about="http://nomisma.org/ontology#ObjectType"/>
+    
+
+
+    <!-- http://nomisma.org/ontology#ReferenceWork -->
+
+    <owl:NamedIndividual rdf:about="http://nomisma.org/ontology#ReferenceWork"/>
+    
+
+
+    <!-- http://nomisma.org/ontology#Region -->
+
+    <owl:NamedIndividual rdf:about="http://nomisma.org/ontology#Region"/>
+    
+
+
+    <!-- http://nomisma.org/ontology#Seal -->
+
+    <owl:NamedIndividual rdf:about="http://nomisma.org/ontology#Seal"/>
+    
+
+
+    <!-- http://nomisma.org/ontology#Tessera -->
+
+    <owl:NamedIndividual rdf:about="http://nomisma.org/ontology#Tessera"/>
+    
+
+
+    <!-- http://nomisma.org/ontology#Token -->
+
+    <owl:NamedIndividual rdf:about="http://nomisma.org/ontology#Token"/>
+    
+
+
+    <!-- http://nomisma.org/ontology#TypeSeries -->
+
+    <owl:NamedIndividual rdf:about="http://nomisma.org/ontology#TypeSeries"/>
+    
+
+
+    <!-- http://nomisma.org/ontology#TypeSeriesItem -->
+
+    <owl:NamedIndividual rdf:about="http://nomisma.org/ontology#TypeSeriesItem"/>
+    
+
+
+    <!-- http://nomisma.org/ontology#Wear -->
+
+    <owl:NamedIndividual rdf:about="http://nomisma.org/ontology#Wear"/>
+    
+
+
+    <!-- http://nomisma.org/ontology#WeightStandard -->
+
+    <owl:NamedIndividual rdf:about="http://nomisma.org/ontology#WeightStandard"/>
+    
+
+
+    <!-- 
+    ///////////////////////////////////////////////////////////////////////////////////////
+    //
+    // Annotations
+    //
+    ///////////////////////////////////////////////////////////////////////////////////////
+     -->
+
+    <rdf:Description rdf:about="http://nomisma.org/ontology#Ethnic">
+        <rdfs:label>Ethnic</rdfs:label>
+        <skos:definition rdf:datatype="&xsd;string">Generally, a tribal or ethnic name appearing on a coin. Distinct from personal authority as indicated by the presence of ruler&apos;s name.</skos:definition>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://nomisma.org/ontology#Wear">
+        <rdfs:label>Wear</rdfs:label>
+        <skos:definition rdf:datatype="&xsd;string">Wear on a numismatic object occurring as a result of its use.</skos:definition>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://nomisma.org/ontology#FieldOfNumismatics">
+        <rdfs:label>FieldOfNumismatics</rdfs:label>
+        <skos:definition rdf:datatype="&xsd;string">Any widely recognized area of study within the discipline of numismatics.</skos:definition>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://nomisma.org/ontology#Mint">
+        <rdfs:label>Mint</rdfs:label>
+        <skos:definition rdf:datatype="&xsd;string">Generic term for a place of manufacture of a coin or for the issuing city.</skos:definition>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://nomisma.org/ontology#Material">
+        <rdfs:label>Material</rdfs:label>
+        <skos:definition rdf:datatype="&xsd;string">The physical material from which an object is made.</skos:definition>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://nomisma.org/ontology#Collection">
+        <rdfs:label>Collection</rdfs:label>
+        <skos:definition rdf:datatype="&xsd;string">General term meaning the objects held by an institution or individual. Or the holding entity itself.</skos:definition>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://nomisma.org/ontology#ReferenceWork">
+        <rdfs:label>ReferenceWork</rdfs:label>
+        <skos:definition rdf:datatype="&xsd;string">A published work of reference relevant to a numismatic object.</skos:definition>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://nomisma.org/ontology#CoinWear">
+        <rdfs:label>CoinWear</rdfs:label>
+        <skos:definition rdf:datatype="&xsd;string">Wear on a coin occurring as a result of its use.</skos:definition>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://nomisma.org/ontology#WeightStandard">
+        <rdfs:label>WeightStandard</rdfs:label>
+        <skos:definition rdf:datatype="&xsd;string">The conventional weight system according to which a numismatic object was produced.</skos:definition>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://nomisma.org/ontology#TypeSeries">
+        <rdfs:label>TypeSeries</rdfs:label>
+        <skos:definition rdf:datatype="&xsd;string">A published or recognized reference list of coin types, such as a catalogue or corpus.</skos:definition>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://nomisma.org/ontology#ObjectType">
+        <rdfs:label>ObjectType</rdfs:label>
+        <skos:definition rdf:datatype="&xsd;string">The numismatic type of an object. Ex. &apos;coin&apos;.</skos:definition>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://nomisma.org/ontology#Region">
+        <rdfs:label>Region</rdfs:label>
+        <skos:definition rdf:datatype="&xsd;string">An area of geographic significance and/or taxonomic importance, perhaps part of a larger geographic/administrative unit, having definable characteristics but not always fixed boundaries.</skos:definition>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://nomisma.org/ontology#Denomination">
+        <rdfs:label>Denomination</rdfs:label>
+        <skos:definition rdf:datatype="&xsd;string">Term indicating the value of a coin. Examples: tetradrachm, chalkous, denarius.</skos:definition>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://nomisma.org/ontology#Manufacture">
+        <rdfs:label>Manufacture</rdfs:label>
+        <skos:definition rdf:datatype="&xsd;string">The technique of manufacture. For example, struck or cast.</skos:definition>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://nomisma.org/ontology#TypeSeriesItem">
+        <rdfs:label>TypeSeriesItem</rdfs:label>
+        <skos:definition rdf:datatype="&xsd;string">An item within a reference list of coin types.</skos:definition>
+    </rdf:Description>
+</rdf:RDF>
+
+
+
+<!-- Generated by the OWL API (version 3.5.1) http://owlapi.sourceforge.net -->
+

--- a/ontology/ontology.161114.ttl
+++ b/ontology/ontology.161114.ttl
@@ -1,0 +1,1314 @@
+@prefix : <http://nomisma.org/ontology#> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix xml: <http://www.w3.org/XML/1998/namespace> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+@base <http://nomisma.org/ontology#> .
+
+<http://nomisma.org/ontology#> rdf:type owl:Ontology ;
+                               
+                               skos:definition "Nomisma.org is a collaborative project to provide stable digital representations of numismatic concepts according to the principles of Linked Open Data. These take the form of http URIs that also provide access to reusable information about those concepts, along with links to other resources."^^xsd:string .
+
+
+#################################################################
+#
+#    Annotation properties
+#
+#################################################################
+
+
+###  http://www.w3.org/2004/02/skos/core#definition
+
+skos:definition rdf:type owl:AnnotationProperty .
+
+
+
+
+
+#################################################################
+#
+#    Object Properties
+#
+#################################################################
+
+
+###  http://nomisma.org/ontology#hasAppearance
+
+:hasAppearance rdf:type owl:ObjectProperty ;
+               
+               rdfs:label "hasAppearance" ;
+               
+               skos:definition "Describes the appearance of a numismatic object. Eg. Iconography, legends and physical characteristics."^^xsd:string .
+
+
+
+###  http://nomisma.org/ontology#hasAuthority
+
+:hasAuthority rdf:type owl:ObjectProperty ;
+              
+              rdfs:label "hasAuthority" ;
+              
+              skos:definition "Identifies the authority in whose name (explicitly or implicitly) a numismatic object was issued. Eg. Charlemagne, Augustus, Sparta, Federal Republic of Germany, Bank of England"^^xsd:string .
+
+
+
+###  http://nomisma.org/ontology#hasAxis
+
+:hasAxis rdf:type owl:ObjectProperty ;
+         
+         rdfs:label "hasAxis" ;
+         
+         skos:definition "Describes the directional relationship between the obverse and reverse of a numismatic object."^^xsd:string .
+
+
+
+###  http://nomisma.org/ontology#hasBearsDate
+
+:hasBearsDate rdf:type owl:ObjectProperty ;
+              
+              rdfs:label "hasBearsDate" ;
+              
+              skos:definition "Describes a date that appears on an object"^^xsd:string ;
+              
+              rdfs:subPropertyOf :hasAppearance .
+
+
+
+###  http://nomisma.org/ontology#hasCollection
+
+:hasCollection rdf:type owl:ObjectProperty ;
+               
+               rdfs:label "hasCollection" ;
+               
+               skos:definition "Identifies the modern collection or repository in which a coin resides or has resided in the past. Collections are defined by Nomisma IDs"^^xsd:string .
+
+
+
+###  http://nomisma.org/ontology#hasContext
+
+:hasContext rdf:type owl:ObjectProperty ;
+            
+            rdfs:label "hasContext"^^xsd:string ;
+            
+            skos:definition "Describes the context of a numismatic object."^^xsd:string .
+
+
+
+###  http://nomisma.org/ontology#hasControlmark
+
+:hasControlmark rdf:type owl:ObjectProperty ;
+                
+                rdfs:label "hasControlmark" ;
+                
+                skos:definition "Identifies a letter, symbol or an inscription on an object intended to distinguish it as part of a group of coins within an issue or series."^^xsd:string ;
+                
+                rdfs:subPropertyOf :hasPeculiarityOfProduction .
+
+
+
+###  http://nomisma.org/ontology#hasCorrosion
+
+:hasCorrosion rdf:type owl:ObjectProperty ;
+              
+              rdfs:label "hasCorrosion" ;
+              
+              skos:definition "Describes degradation due to chemical reaction with an environment, commonly in terms prescribed by \"Abnutzung und Korrosion: Bestimmmungstafeln zur Bearbeitung von Fundmünzen = Usure et corrosion. (1995). Lausanne.\" (OCLC 174260520)"^^xsd:string .
+
+
+
+###  http://nomisma.org/ontology#hasCountermark
+
+:hasCountermark rdf:type owl:ObjectProperty ;
+                
+                rdfs:label "hasCountermark" ;
+                
+                skos:definition "Identifies a mark or symbol punched into an object at some point during its time in circulation."^^xsd:string ;
+                
+                rdfs:subPropertyOf :hasIconography ,
+                                   :hasSecondaryTreatment .
+
+
+
+###  http://nomisma.org/ontology#hasDate
+
+:hasDate rdf:type owl:ObjectProperty ;
+         
+         rdfs:label "hasDate" ;
+         
+         skos:definition "Describes date (range) assigned in a numismatic context."^^xsd:string .
+
+
+
+###  http://nomisma.org/ontology#hasDenomination
+
+:hasDenomination rdf:type owl:ObjectProperty ;
+                 
+                 rdfs:label "hasDenomination" ;
+                 
+                 skos:definition "Describes the monetary value assigned to an object within a denominational system. Examples: tetradrachm, chalkous, denarius."^^xsd:string .
+
+
+
+###  http://nomisma.org/ontology#hasDepth
+
+:hasDepth rdf:type owl:ObjectProperty ;
+          
+          rdfs:label "hasDepth" ;
+          
+          skos:definition "Describes the depth of an object."^^xsd:string .
+
+
+
+###  http://nomisma.org/ontology#hasDiameter
+
+:hasDiameter rdf:type owl:ObjectProperty ;
+             
+             rdfs:label "hasDiameter" ;
+             
+             skos:definition "Describes diameter of an object."^^xsd:string .
+
+
+
+###  http://nomisma.org/ontology#hasDie
+
+:hasDie rdf:type owl:ObjectProperty ;
+        
+        rdfs:label "hasDie" ;
+        
+        skos:definition "Describes the die from which a numismatic object has been produced."^^xsd:string ;
+        
+        rdfs:subPropertyOf :hasProductionObject .
+
+
+
+###  http://nomisma.org/ontology#hasEdge
+
+:hasEdge rdf:type owl:ObjectProperty ;
+         
+         rdfs:label "hasEdge" ;
+         
+         skos:definition "Describes characteristics of the edge of a numismatic object."^^xsd:string ;
+         
+         rdfs:subPropertyOf :hasAppearance .
+
+
+
+###  http://nomisma.org/ontology#hasEndDate
+
+:hasEndDate rdf:type owl:ObjectProperty ;
+            
+            rdfs:label "hasEndDate" ;
+            
+            skos:definition "Identifies the final date in a range assigned in a numismatic context."^^xsd:string ;
+            
+            rdfs:subPropertyOf owl:topObjectProperty .
+
+
+
+###  http://nomisma.org/ontology#hasFace
+
+:hasFace rdf:type owl:ObjectProperty ;
+         
+         rdfs:label "hasFace" ;
+         
+         skos:definition "Identifies a particular face of a numismatic object. Where possible and appropriate, the more specific properties hasObverse or hasReverse are preferred."^^xsd:string ;
+         
+         rdfs:subPropertyOf :hasAppearance .
+
+
+
+###  http://nomisma.org/ontology#hasFindType
+
+:hasFindType rdf:type owl:ObjectProperty ;
+             
+             rdfs:label "hasFindType" ;
+             
+             skos:definition "Describes the nature of and archaeological or other find. E.g. hoard, ritual deposit, single find, find in survey."^^xsd:string ;
+             
+             owl:deprecated "deprecated - please use nmo:hasContext instead, together with the class Context or its sub classes: Find, DepositionType and DiscoveryType"^^xsd:string .
+
+
+
+###  http://nomisma.org/ontology#hasFindspot
+
+:hasFindspot rdf:type owl:ObjectProperty ;
+             
+             rdfs:label "hasFindspot" ;
+             
+             skos:definition "Describes the location of the discovery of an object, whether by accident or in archaeological excavation."^^xsd:string ;
+             
+             rdfs:subPropertyOf owl:topObjectProperty .
+
+
+
+###  http://nomisma.org/ontology#hasHeight
+
+:hasHeight rdf:type owl:ObjectProperty ;
+           
+           rdfs:label "hasHeight" ;
+           
+           skos:definition "Describes the height of a numismatic object."^^xsd:string .
+
+
+
+###  http://nomisma.org/ontology#hasIconography
+
+:hasIconography rdf:type owl:ObjectProperty ;
+                
+                rdfs:label "hasIconography" ;
+                
+                skos:definition "Describes an iconography placed on a numismatic object."^^xsd:string ;
+                
+                rdfs:subPropertyOf :hasAppearance .
+
+
+
+###  http://nomisma.org/ontology#hasIssuer
+
+:hasIssuer rdf:type owl:ObjectProperty ;
+           
+           rdfs:label "hasIssuer" ;
+           
+           skos:definition "Identifies the person administratively responsible for the issue of a numismatic object, generally named in some capacity on the object."^^xsd:string .
+
+
+
+###  http://nomisma.org/ontology#hasLegend
+
+:hasLegend rdf:type owl:ObjectProperty ;
+           
+           rdfs:label "hasLegend" ;
+           
+           skos:definition "Describes the inscription or printing placed on a numismatic object as part of the production process."^^xsd:string ;
+           
+           rdfs:subPropertyOf :hasAppearance .
+
+
+
+###  http://nomisma.org/ontology#hasManufacture
+
+:hasManufacture rdf:type owl:ObjectProperty ;
+                
+                rdfs:label "hasManufacture" ;
+                
+                skos:definition "Describes the method of manufacture of a numismatic object. Eg. struck, cast, printed"^^xsd:string .
+
+
+
+###  http://nomisma.org/ontology#hasMaterial
+
+:hasMaterial rdf:type owl:ObjectProperty ;
+             
+             rdfs:label "hasMaterial" ;
+             
+             skos:definition "Describes the physical material from which a numismatic object is made."^^xsd:string .
+
+
+
+###  http://nomisma.org/ontology#hasMaxDepth
+
+:hasMaxDepth rdf:type owl:ObjectProperty ;
+             
+             rdfs:label "hasMaxDepth" ;
+             
+             skos:definition "Describes the maximum depth of a numismatic object."^^xsd:string ;
+             
+             rdfs:subPropertyOf :hasDepth .
+
+
+
+###  http://nomisma.org/ontology#hasMaxDiameter
+
+:hasMaxDiameter rdf:type owl:ObjectProperty ;
+                
+                rdfs:label "hasMaxDiameter" ;
+                
+                skos:definition "Describes the maximum diameter of a numismatic object."^^xsd:string ;
+                
+                rdfs:subPropertyOf :hasDiameter .
+
+
+
+###  http://nomisma.org/ontology#hasMaxHeight
+
+:hasMaxHeight rdf:type owl:ObjectProperty ;
+              
+              rdfs:label "hasMaxHeight" ;
+              
+              skos:definition "Describes the maximum height of a numismatic object."^^xsd:string ;
+              
+              rdfs:subPropertyOf :hasHeight .
+
+
+
+###  http://nomisma.org/ontology#hasMaxWidth
+
+:hasMaxWidth rdf:type owl:ObjectProperty ;
+             
+             rdfs:label "hasMaxWidth" ;
+             
+             skos:definition "Describes the maximum width of a numismatic object."^^xsd:string ;
+             
+             rdfs:subPropertyOf :hasWidth .
+
+
+
+###  http://nomisma.org/ontology#hasMinDepth
+
+:hasMinDepth rdf:type owl:ObjectProperty ;
+             
+             rdfs:label "hasMinDepth" ;
+             
+             skos:definition "Describes the minimum depth of a numismatic object."^^xsd:string ;
+             
+             rdfs:subPropertyOf :hasDepth .
+
+
+
+###  http://nomisma.org/ontology#hasMinDiameter
+
+:hasMinDiameter rdf:type owl:ObjectProperty ;
+                
+                rdfs:label "hasMinDiameter" ;
+                
+                skos:definition "Describes the minimum diameter of a numismatic object."^^xsd:string ;
+                
+                rdfs:subPropertyOf :hasDiameter .
+
+
+
+###  http://nomisma.org/ontology#hasMinHeight
+
+:hasMinHeight rdf:type owl:ObjectProperty ;
+              
+              rdfs:label "hasMinHeight" ;
+              
+              skos:definition "Describes the minimum height of a numismatic object."^^xsd:string ;
+              
+              rdfs:subPropertyOf :hasHeight .
+
+
+
+###  http://nomisma.org/ontology#hasMinWidth
+
+:hasMinWidth rdf:type owl:ObjectProperty ;
+             
+             rdfs:label "hasMinWidth" ;
+             
+             skos:definition "Describes the minimum width of a numismatic object."^^xsd:string ;
+             
+             rdfs:subPropertyOf :hasWidth .
+
+
+
+###  http://nomisma.org/ontology#hasMint
+
+:hasMint rdf:type owl:ObjectProperty ;
+         
+         rdfs:label "hasMint" ;
+         
+         skos:definition "Identifies the place of manufacture or issue of a numismatic object."^^xsd:string .
+
+
+
+###  http://nomisma.org/ontology#hasMintmark
+
+:hasMintmark rdf:type owl:ObjectProperty ;
+             
+             rdfs:label "hasMintmark" ;
+             
+             skos:definition "Identifies the letter, symbol or an inscription on a numismatic object indicating the mint where it was produced."^^xsd:string ;
+             
+             rdfs:subPropertyOf :hasControlmark ,
+                                :hasIconography .
+
+
+
+###  http://nomisma.org/ontology#hasMonogram
+
+:hasMonogram rdf:type owl:ObjectProperty ;
+             
+             rdfs:label "hasMonogram" ;
+             
+             skos:definition "Identifies the monogram that appears on a numismatic object."^^xsd:string ;
+             
+             rdfs:subPropertyOf :hasIconography .
+
+
+
+###  http://nomisma.org/ontology#hasObjectType
+
+:hasObjectType rdf:type owl:ObjectProperty ;
+               
+               rdfs:label "hasObjectType" ;
+               
+               skos:definition "Identifies the type of numismatic object. E.g. Coin, token, banknote."^^xsd:string .
+
+
+
+###  http://nomisma.org/ontology#hasObverse
+
+:hasObverse rdf:type owl:ObjectProperty ;
+            
+            rdfs:label "hasObverse" ;
+            
+            skos:definition "Identifies a particular face of a numismatic object. Normally it will be the face carrying the represenation, badge or inscription of the issuing authority. In ancient, hand-struck coinage it is generally the lower (anvil) die. In English often known as \"heads\"."^^xsd:string ;
+            
+            rdfs:subPropertyOf :hasFace .
+
+
+
+###  http://nomisma.org/ontology#hasPeculiarity
+
+:hasPeculiarity rdf:type owl:ObjectProperty ;
+                
+                rdfs:label "hasPeculiarity" ;
+                
+                skos:definition "Describes a feature of an individual numismatic object that marks it out from other objects of the same type. Can a result of production, such as plating, or post-production activity, such as piercing, cutting or mounting."^^xsd:string .
+
+
+
+###  http://nomisma.org/ontology#hasPeculiarityOfProduction
+
+:hasPeculiarityOfProduction rdf:type owl:ObjectProperty ;
+                            
+                            rdfs:label "hasPeculiarityOfProduction" ;
+                            
+                            skos:definition "Describes anomalies or unusual features which are related to the process of production of a numismatic object; for example serratus, plating, doublestrike, etc."^^xsd:string ;
+                            
+                            rdfs:subPropertyOf :hasPeculiarity .
+
+
+
+###  http://nomisma.org/ontology#hasPortrait
+
+:hasPortrait rdf:type owl:ObjectProperty ;
+             
+             rdfs:label "hasPortrait" ;
+             
+             skos:definition "Identifies the person whose portrait appears on a numismatic object."^^xsd:string ;
+             
+             rdfs:subPropertyOf :hasIconography .
+
+
+
+###  http://nomisma.org/ontology#hasProductionDate
+
+:hasProductionDate rdf:type owl:ObjectProperty ;
+                   
+                   rdfs:label "hasProductionDate" ;
+                   
+                   skos:definition "Describes the date (range) of the production of a numismatic object."^^xsd:string ;
+                   
+                   rdfs:subPropertyOf :hasDate .
+
+
+
+###  http://nomisma.org/ontology#hasProductionObject
+
+:hasProductionObject rdf:type owl:ObjectProperty ;
+                     
+                     rdfs:label "hasProductionObject" ;
+                     
+                     skos:definition ""^^xsd:string .
+
+
+
+###  http://nomisma.org/ontology#hasReferenceWork
+
+:hasReferenceWork rdf:type owl:ObjectProperty ;
+                  
+                  rdfs:label "hasReferenceWork" ;
+                  
+                  skos:definition "Specifies a published work of reference relevant to a numismatic object."^^xsd:string .
+
+
+
+###  http://nomisma.org/ontology#hasReverse
+
+:hasReverse rdf:type owl:ObjectProperty ;
+            
+            rdfs:label "hasReverse" ;
+            
+            skos:definition "Identifies a the face of a numismatic object opposed to the obverse. In ancient, hand-struck coinage it is generally the upper die. In English often known as \"tails\"."^^xsd:string ;
+            
+            rdfs:subPropertyOf :hasFace .
+
+
+
+###  http://nomisma.org/ontology#hasSecondaryTreatment
+
+:hasSecondaryTreatment rdf:type owl:ObjectProperty ;
+                       
+                       rdfs:label "hasSecondaryTreatment" ;
+                       
+                       skos:definition "Describes anomalies or unusual features which arise subsequent to the actual production of a coin; for example halving, chop-marking, etc."^^xsd:string ;
+                       
+                       rdfs:subPropertyOf :hasPeculiarity .
+
+
+
+###  http://nomisma.org/ontology#hasShape
+
+:hasShape rdf:type owl:ObjectProperty ;
+          
+          rdfs:label "hasShape"^^xsd:string ;
+          
+          skos:definition "Describes the shape of a numismatic object."^^xsd:string .
+
+
+
+###  http://nomisma.org/ontology#hasStartDate
+
+:hasStartDate rdf:type owl:ObjectProperty ;
+              
+              rdfs:label "hasStartDate" ;
+              
+              skos:definition "Identifies the initial date in a range assigned in a numismatic context."^^xsd:string ;
+              
+              rdfs:subPropertyOf owl:topObjectProperty .
+
+
+
+###  http://nomisma.org/ontology#hasStatedAuthority
+
+:hasStatedAuthority rdf:type owl:ObjectProperty ;
+                    
+                    rdfs:label "hasStatedAuthority" ;
+                    
+                    skos:definition "The authority as stated on a numismatic object. This may, but need not, be the same as the real authority behind the object (expressed separately as hasAuthority)."^^xsd:string .
+
+
+
+###  http://nomisma.org/ontology#hasTypeSeriesItem
+
+:hasTypeSeriesItem rdf:type owl:ObjectProperty ;
+                   
+                   rdfs:label "hasTypeSeriesItem" ;
+                   
+                   skos:definition "Identifies the position of a numismatic object within a published or recognized reference list of coin types, such as a catalogue or corpus."^^xsd:string .
+
+
+
+###  http://nomisma.org/ontology#hasWear
+
+:hasWear rdf:type owl:ObjectProperty ;
+         
+         rdfs:label "hasWear" ;
+         
+         skos:definition "Describes wear visible on a numismatic object due to use or circulation, commonly in terms prescribed by \"Abnutzung und Korrosion: Bestimmmungstafeln zur Bearbeitung von Fundmünzen = Usure et corrosion. (1995). Lausanne.\" (OCLC 174260520)"^^xsd:string .
+
+
+
+###  http://nomisma.org/ontology#hasWeight
+
+:hasWeight rdf:type owl:ObjectProperty ;
+           
+           rdfs:label "hasWeight" ;
+           
+           skos:definition "Describes the actual weight of a numismatic object."^^xsd:string .
+
+
+
+###  http://nomisma.org/ontology#hasWeightStandard
+
+:hasWeightStandard rdf:type owl:ObjectProperty ;
+                   
+                   rdfs:label "hasWeightStandard" ;
+                   
+                   skos:definition "Describes the conventional weight system according to which a numismatic object of intrinsic value was produced."^^xsd:string .
+
+
+
+###  http://nomisma.org/ontology#hasWidth
+
+:hasWidth rdf:type owl:ObjectProperty ;
+          
+          rdfs:label "hasWidth" ;
+          
+          skos:definition "Describes the width of a numismatic object."^^xsd:string ;
+          
+          rdfs:subPropertyOf owl:topObjectProperty .
+
+
+
+###  http://nomisma.org/ontology#representsObjectType
+
+:representsObjectType rdf:type owl:ObjectProperty ;
+                      
+                      rdfs:label "representsObjectType" ;
+                      
+                      skos:definition "To indicate what kind of object type is represented by (for example) an type series item (a coin, banknote, token, ...)."^^xsd:string .
+
+
+
+
+
+#################################################################
+#
+#    Classes
+#
+#################################################################
+
+
+###  http://nomisma.org/ontology#CoinWear
+
+:CoinWear rdf:type owl:Class ;
+          
+          rdfs:subClassOf :Wear .
+
+
+
+###  http://nomisma.org/ontology#Collection
+
+:Collection rdf:type owl:Class .
+
+
+
+###  http://nomisma.org/ontology#Context
+
+:Context rdf:type owl:Class ;
+         
+         rdfs:label "Context" ;
+         
+         skos:definition "The archaeological context of a numismatic object. "^^xsd:string .
+
+
+
+###  http://nomisma.org/ontology#Controlmark
+
+:Controlmark rdf:type owl:Class ;
+             
+             rdfs:label "Controlmark" ;
+             
+             skos:definition "A control mark is a letter, symbol or an inscription on a coin intended to distinguish a group of coins within an issue or series."^^xsd:string .
+
+
+
+###  http://nomisma.org/ontology#Corrosion
+
+:Corrosion rdf:type owl:Class ;
+           
+           rdfs:label "Corrosion" ;
+           
+           skos:definition "Degradation to a numismatic object due to chemical reaction with its environment."^^xsd:string .
+
+
+
+###  http://nomisma.org/ontology#Countermark
+
+:Countermark rdf:type owl:Class ;
+             
+             rdfs:label "Countermark" ;
+             
+             rdfs:subClassOf :SecondaryTreatment ;
+             
+             skos:definition "A mark or symbol punched into a coin at some point during its time in circulation."^^xsd:string .
+
+
+
+###  http://nomisma.org/ontology#Denomination
+
+:Denomination rdf:type owl:Class .
+
+
+
+###  http://nomisma.org/ontology#DepositionType
+
+:DepositionType rdf:type owl:Class ;
+                
+                rdfs:label "DepositionType" ;
+                
+                rdfs:subClassOf :Context ;
+                
+                skos:definition "The circumstances under which an object or group of objects came to be deposited and part of the archaeological record, for example as a hoard, votive deposit or chance loss."^^xsd:string .
+
+
+
+###  http://nomisma.org/ontology#DieWear
+
+:DieWear rdf:type owl:Class ;
+         
+         rdfs:label "DieWear" ;
+         
+         rdfs:subClassOf :Wear ;
+         
+         skos:definition "Wear on a die occurring as a result of its use."^^xsd:string .
+
+
+
+###  http://nomisma.org/ontology#DiscoveryType
+
+:DiscoveryType rdf:type owl:Class ;
+               
+               rdfs:label "DiscoveryType" ;
+               
+               rdfs:subClassOf :Context ;
+               
+               skos:definition "The circumstances under which an object or group of objects came to be discovered, for example as a chance stray find or a controlled excavation."^^xsd:string .
+
+
+
+###  http://nomisma.org/ontology#Ethnic
+
+:Ethnic rdf:type owl:Class .
+
+
+
+###  http://nomisma.org/ontology#FieldOfNumismatics
+
+:FieldOfNumismatics rdf:type owl:Class .
+
+
+
+###  http://nomisma.org/ontology#Find
+
+:Find rdf:type owl:Class ;
+      
+      rdfs:label "Find" ;
+      
+      rdfs:subClassOf :Context ;
+      
+      skos:definition "A numismatic object or group of numismatic objects that was lost or deposited, whether intentionally or unintentionally, in previous times, and subsequently recovered. The recovery takes place independently of any intention of retrieval associated with the original deposition."^^xsd:string .
+
+
+
+###  http://nomisma.org/ontology#Manufacture
+
+:Manufacture rdf:type owl:Class .
+
+
+
+###  http://nomisma.org/ontology#Material
+
+:Material rdf:type owl:Class .
+
+
+
+###  http://nomisma.org/ontology#Mint
+
+:Mint rdf:type owl:Class .
+
+
+
+###  http://nomisma.org/ontology#Mintmark
+
+:Mintmark rdf:type owl:Class ;
+          
+          rdfs:label "Mintmark" ;
+          
+          rdfs:subClassOf :Controlmark ;
+          
+          skos:definition "A mint mark is a letter, symbol or an inscription on a coin indicating the mint where the coin was produced."^^xsd:string .
+
+
+
+###  http://nomisma.org/ontology#Monogram
+
+:Monogram rdf:type owl:Class ;
+          
+          rdfs:label "Monogram" ;
+          
+          skos:definition "A monogram is a symbol made by overlapping or combining of letters or other graphemes."^^xsd:string .
+
+
+
+###  http://nomisma.org/ontology#NumismaticObject
+
+:NumismaticObject rdf:type owl:Class ;
+                  
+                  rdfs:label "NumismaticObject" ;
+                  
+                  skos:definition "The physical objects that are of interest in the numismatic domain."^^xsd:string .
+
+
+
+###  http://nomisma.org/ontology#NumismaticTerm
+
+:NumismaticTerm rdf:type owl:Class ;
+                
+                rdfs:label "NumismaticTerm" ;
+                
+                skos:definition "A term used within the field of numismatics to describe or to otherwise convey information specific to the numismatic discipline, or to numismatic objects."^^xsd:string .
+
+
+
+###  http://nomisma.org/ontology#ObjectType
+
+:ObjectType rdf:type owl:Class .
+
+
+
+###  http://nomisma.org/ontology#Peculiarity
+
+:Peculiarity rdf:type owl:Class ;
+             
+             rdfs:label "Peculiarity" ;
+             
+             skos:definition "A feature of a numismatic object that is not part of the original design. "^^xsd:string .
+
+
+
+###  http://nomisma.org/ontology#PeculiarityOfProduction
+
+:PeculiarityOfProduction rdf:type owl:Class ;
+                         
+                         rdfs:label "PeculiarityOfProduction" ;
+                         
+                         rdfs:subClassOf :Peculiarity ;
+                         
+                         skos:definition "Anomalies or unusual features which are related to the process of production of a coin; for example serratus, plating, doublestrike, etc."^^xsd:string .
+
+
+
+###  http://nomisma.org/ontology#ReferenceWork
+
+:ReferenceWork rdf:type owl:Class .
+
+
+
+###  http://nomisma.org/ontology#Region
+
+:Region rdf:type owl:Class .
+
+
+
+###  http://nomisma.org/ontology#SecondaryTreatment
+
+:SecondaryTreatment rdf:type owl:Class ;
+                    
+                    rdfs:label "SecondaryTreatment" ;
+                    
+                    rdfs:subClassOf :Peculiarity ;
+                    
+                    skos:definition "Anomalies or unusual features which arise subsequent to the actual production of a coin; for example halving, chop-marking, etc."^^xsd:string .
+
+
+
+###  http://nomisma.org/ontology#Shape
+
+:Shape rdf:type owl:Class ;
+       
+       rdfs:label "Shape" ;
+       
+       skos:definition "The possible shapes numismatic objects might have, could be standard like round or rectangular or even a polygon." .
+
+
+
+###  http://nomisma.org/ontology#TypeSeries
+
+:TypeSeries rdf:type owl:Class ;
+            
+            rdfs:subClassOf :ReferenceWork .
+
+
+
+###  http://nomisma.org/ontology#TypeSeriesItem
+
+:TypeSeriesItem rdf:type owl:Class .
+
+
+
+###  http://nomisma.org/ontology#Wear
+
+:Wear rdf:type owl:Class .
+
+
+
+###  http://nomisma.org/ontology#WeightStandard
+
+:WeightStandard rdf:type owl:Class .
+
+
+
+
+
+#################################################################
+#
+#    Individuals
+#
+#################################################################
+
+
+###  http://nomisma.org/id/coin
+
+<http://nomisma.org/id/coin> rdf:type owl:NamedIndividual ;
+                             
+                             owl:sameAs :Coin .
+
+
+
+###  http://nomisma.org/id/coin_wear
+
+<http://nomisma.org/id/coin_wear> rdf:type owl:NamedIndividual ;
+                                  
+                                  owl:sameAs :CoinWear .
+
+
+
+###  http://nomisma.org/id/collection
+
+<http://nomisma.org/id/collection> rdf:type owl:NamedIndividual ;
+                                   
+                                   owl:sameAs :Collection .
+
+
+
+###  http://nomisma.org/id/denomination
+
+<http://nomisma.org/id/denomination> rdf:type owl:NamedIndividual ;
+                                     
+                                     owl:sameAs :Denomination .
+
+
+
+###  http://nomisma.org/id/ethnic
+
+<http://nomisma.org/id/ethnic> rdf:type owl:NamedIndividual ;
+                               
+                               owl:sameAs :Ethnic .
+
+
+
+###  http://nomisma.org/id/field_of_numismatics
+
+<http://nomisma.org/id/field_of_numismatics> rdf:type owl:NamedIndividual ;
+                                             
+                                             owl:sameAs :FieldOfNumismatics .
+
+
+
+###  http://nomisma.org/id/manufacture
+
+<http://nomisma.org/id/manufacture> rdf:type owl:NamedIndividual ;
+                                    
+                                    owl:sameAs :Manufacture .
+
+
+
+###  http://nomisma.org/id/material
+
+<http://nomisma.org/id/material> rdf:type owl:NamedIndividual ;
+                                 
+                                 owl:sameAs :Material .
+
+
+
+###  http://nomisma.org/id/medal
+
+<http://nomisma.org/id/medal> rdf:type owl:NamedIndividual ;
+                              
+                              owl:sameAs :Medal .
+
+
+
+###  http://nomisma.org/id/mint
+
+<http://nomisma.org/id/mint> rdf:type owl:NamedIndividual ;
+                             
+                             owl:sameAs :Mint .
+
+
+
+###  http://nomisma.org/id/object_type
+
+<http://nomisma.org/id/object_type> rdf:type owl:NamedIndividual ;
+                                    
+                                    owl:sameAs :ObjectType .
+
+
+
+###  http://nomisma.org/id/reference_work
+
+<http://nomisma.org/id/reference_work> rdf:type owl:NamedIndividual ;
+                                       
+                                       owl:sameAs :ReferenceWork .
+
+
+
+###  http://nomisma.org/id/region
+
+<http://nomisma.org/id/region> rdf:type owl:NamedIndividual ;
+                               
+                               owl:sameAs :Region .
+
+
+
+###  http://nomisma.org/id/seal
+
+<http://nomisma.org/id/seal> rdf:type owl:NamedIndividual ;
+                             
+                             owl:sameAs :Seal .
+
+
+
+###  http://nomisma.org/id/tessera
+
+<http://nomisma.org/id/tessera> rdf:type owl:NamedIndividual ;
+                                
+                                owl:sameAs :Tessera .
+
+
+
+###  http://nomisma.org/id/token
+
+<http://nomisma.org/id/token> rdf:type owl:NamedIndividual ;
+                              
+                              owl:sameAs :Token .
+
+
+
+###  http://nomisma.org/id/type_series
+
+<http://nomisma.org/id/type_series> rdf:type owl:NamedIndividual ;
+                                    
+                                    owl:sameAs :TypeSeries .
+
+
+
+###  http://nomisma.org/id/type_series_item
+
+<http://nomisma.org/id/type_series_item> rdf:type owl:NamedIndividual ;
+                                         
+                                         owl:sameAs :TypeSeriesItem .
+
+
+
+###  http://nomisma.org/id/weight_standard
+
+<http://nomisma.org/id/weight_standard> rdf:type owl:NamedIndividual ;
+                                        
+                                        owl:sameAs :WeightStandard .
+
+
+
+###  http://nomisma.org/ontology#Coin
+
+:Coin rdf:type owl:NamedIndividual .
+
+
+
+###  http://nomisma.org/ontology#CoinWear
+
+:CoinWear rdf:type owl:NamedIndividual .
+
+
+
+###  http://nomisma.org/ontology#Collection
+
+:Collection rdf:type owl:NamedIndividual .
+
+
+
+###  http://nomisma.org/ontology#Denomination
+
+:Denomination rdf:type owl:NamedIndividual .
+
+
+
+###  http://nomisma.org/ontology#Ethnic
+
+:Ethnic rdf:type owl:NamedIndividual .
+
+
+
+###  http://nomisma.org/ontology#FieldOfNumismatics
+
+:FieldOfNumismatics rdf:type owl:NamedIndividual .
+
+
+
+###  http://nomisma.org/ontology#Manufacture
+
+:Manufacture rdf:type owl:NamedIndividual .
+
+
+
+###  http://nomisma.org/ontology#Material
+
+:Material rdf:type owl:NamedIndividual .
+
+
+
+###  http://nomisma.org/ontology#Medal
+
+:Medal rdf:type owl:NamedIndividual .
+
+
+
+###  http://nomisma.org/ontology#Medallion
+
+:Medallion rdf:type owl:NamedIndividual .
+
+
+
+###  http://nomisma.org/ontology#Mint
+
+:Mint rdf:type owl:NamedIndividual .
+
+
+
+###  http://nomisma.org/ontology#ObjectType
+
+:ObjectType rdf:type owl:NamedIndividual .
+
+
+
+###  http://nomisma.org/ontology#ReferenceWork
+
+:ReferenceWork rdf:type owl:NamedIndividual .
+
+
+
+###  http://nomisma.org/ontology#Region
+
+:Region rdf:type owl:NamedIndividual .
+
+
+
+###  http://nomisma.org/ontology#Seal
+
+:Seal rdf:type owl:NamedIndividual .
+
+
+
+###  http://nomisma.org/ontology#Tessera
+
+:Tessera rdf:type owl:NamedIndividual .
+
+
+
+###  http://nomisma.org/ontology#Token
+
+:Token rdf:type owl:NamedIndividual .
+
+
+
+###  http://nomisma.org/ontology#TypeSeries
+
+:TypeSeries rdf:type owl:NamedIndividual .
+
+
+
+###  http://nomisma.org/ontology#TypeSeriesItem
+
+:TypeSeriesItem rdf:type owl:NamedIndividual .
+
+
+
+###  http://nomisma.org/ontology#Wear
+
+:Wear rdf:type owl:NamedIndividual .
+
+
+
+###  http://nomisma.org/ontology#WeightStandard
+
+:WeightStandard rdf:type owl:NamedIndividual .
+
+
+
+
+
+#################################################################
+#
+#    Annotations
+#
+#################################################################
+
+
+:Ethnic rdfs:label "Ethnic" ;
+        
+        skos:definition "Generally, a tribal or ethnic name appearing on a coin. Distinct from personal authority as indicated by the presence of ruler's name."^^xsd:string .
+
+
+
+:Wear rdfs:label "Wear" ;
+      
+      skos:definition "Wear on a numismatic object occurring as a result of its use."^^xsd:string .
+
+
+
+:FieldOfNumismatics rdfs:label "FieldOfNumismatics" ;
+                    
+                    skos:definition "Any widely recognized area of study within the discipline of numismatics."^^xsd:string .
+
+
+
+:Mint rdfs:label "Mint" ;
+      
+      skos:definition "Generic term for a place of manufacture of a coin or for the issuing city."^^xsd:string .
+
+
+
+:Material rdfs:label "Material" ;
+          
+          skos:definition "The physical material from which an object is made."^^xsd:string .
+
+
+
+:Collection rdfs:label "Collection" ;
+            
+            skos:definition "General term meaning the objects held by an institution or individual. Or the holding entity itself."^^xsd:string .
+
+
+
+:ReferenceWork rdfs:label "ReferenceWork" ;
+               
+               skos:definition "A published work of reference relevant to a numismatic object."^^xsd:string .
+
+
+
+:CoinWear rdfs:label "CoinWear" ;
+          
+          skos:definition "Wear on a coin occurring as a result of its use."^^xsd:string .
+
+
+
+:WeightStandard rdfs:label "WeightStandard" ;
+                
+                skos:definition "The conventional weight system according to which a numismatic object was produced."^^xsd:string .
+
+
+
+:TypeSeries rdfs:label "TypeSeries" ;
+            
+            skos:definition "A published or recognized reference list of coin types, such as a catalogue or corpus."^^xsd:string .
+
+
+
+:ObjectType rdfs:label "ObjectType" ;
+            
+            skos:definition "The numismatic type of an object. Ex. 'coin'."^^xsd:string .
+
+
+
+:Region rdfs:label "Region" ;
+        
+        skos:definition "An area of geographic significance and/or taxonomic importance, perhaps part of a larger geographic/administrative unit, having definable characteristics but not always fixed boundaries."^^xsd:string .
+
+
+
+:Denomination rdfs:label "Denomination" ;
+              
+              skos:definition "Term indicating the value of a coin. Examples: tetradrachm, chalkous, denarius."^^xsd:string .
+
+
+
+:Manufacture rdfs:label "Manufacture" ;
+             
+             skos:definition "The technique of manufacture. For example, struck or cast."^^xsd:string .
+
+
+
+:TypeSeriesItem rdfs:label "TypeSeriesItem" ;
+                
+                skos:definition "An item within a reference list of coin types."^^xsd:string .
+
+
+
+
+###  Generated by the OWL API (version 3.5.1) http://owlapi.sourceforge.net
+


### PR DESCRIPTION
New:

nmo:Shape - "The possible shapes numismatic objects might have, could be
standard like round or rectangular or even a polygon."
nmo:hasShape - "Describes the shape of a numismatic object."
nmo:hasFace - "Identifies a particular face of a numismatic object.
Where possible and appropriate, the more specific properties
hasObverse or hasReverse are preferred.”
nmo:hasContext - "Describes the context of a numismatic object."

Updates:
including description for nmo:Find as: "A numismatic object or group of
numismatic objects that was lost or deposited, whether
intentionally or unintentionally, in previous times, and subsequently
recovered. The recovery takes place independently of any
intention of retrieval associated with the original deposition."

Classes DepositionType and DiscoveryType as subclasses of Context.

Deprecate the property: nmo:hasFindType "deprecated - please use
nmo:hasContext instead, togeher with the class Context or its sub
classes: Find, DepositionType and DiscoveryType"