### PR TITLE
Ontology changes

### DIFF
--- a/ontology/ontology.250402.rdf
+++ b/ontology/ontology.250402.rdf
@@ -1,0 +1,1623 @@
+<?xml version="1.0"?>
+<rdf:RDF xmlns="http://nomisma.org/ontology#"
+     xml:base="http://nomisma.org/ontology"
+     xmlns:crm="http://www.cidoc-crm.org/cidoc-crm/"
+     xmlns:owl="http://www.w3.org/2002/07/owl#"
+     xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+     xmlns:xml="http://www.w3.org/XML/1998/namespace"
+     xmlns:xsd="http://www.w3.org/2001/XMLSchema#"
+     xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
+     xmlns:skos="http://www.w3.org/2004/02/skos/core#"
+     xmlns:dcterms="http://purl.org/dc/terms/"
+     xmlns:dcmitype="http://purl.org/dc/dcmitype/">
+    <owl:Ontology rdf:about="http://nomisma.org/ontology#">
+        <dcterms:date>2025-01-22</dcterms:date>
+        <rdfs:comment xml:lang="en">Nomisma.org is a collaborative project to provide stable digital representations of numismatic concepts according to the principles of Linked Open Data. These take the form of http URIs that also provide access to reusable information about those concepts, along with links to other resources.</rdfs:comment>
+        <owl:versionInfo xml:lang="en">Version of 2025-04-02:
+changes:
+changed from owl:ObjectProperty to rdf:Property
+nmo:hasFindsport as supPropertyOf (sPO) nmo:hasFindContext
+nmo:hasEndDate and nmo:hasStartDate as sPO nmo:hasDate
+nmo:hasStatedAuthority as sPO nmo:Appearance
+nmo:isAbove, nmo:isBelow, nmo:isEqual as sPO of nmo:hasContext
+nmo:hasControlmark as sPO nmo:hasMark
+new:
+nmo:hasMeasurement as SuperProperty for: nmo:hasDiameter, nmo:hasDepth, nmo:hasWidth, nmo:hasHeight, nmo:hasWeight (just for a better structuring)</owl:versionInfo>
+        <skos:definition xml:lang="en">Nomisma.org is a collaborative project to provide stable digital representations of numismatic concepts according to the principles of Linked Open Data. These take the form of http URIs that also provide access to reusable information about those concepts, along with links to other resources.</skos:definition>
+    </owl:Ontology>
+    
+
+
+    <!-- 
+    ///////////////////////////////////////////////////////////////////////////////////////
+    //
+    // Annotation properties
+    //
+    ///////////////////////////////////////////////////////////////////////////////////////
+     -->
+
+    
+
+
+    <!-- http://purl.org/dc/terms/date -->
+
+    <owl:AnnotationProperty rdf:about="http://purl.org/dc/terms/date"/>
+    
+
+
+    <!-- http://www.w3.org/2004/02/skos/core#definition -->
+
+    <owl:AnnotationProperty rdf:about="http://www.w3.org/2004/02/skos/core#definition"/>
+    
+
+
+    <!-- 
+    ///////////////////////////////////////////////////////////////////////////////////////
+    //
+    // Properties
+    //
+    ///////////////////////////////////////////////////////////////////////////////////////
+     -->
+
+    
+
+
+    <!-- http://nomisma.org/ontology#hasAppearance -->
+
+    <rdf:Property rdf:about="http://nomisma.org/ontology#hasAppearance">
+        <rdfs:comment xml:lang="en">Describes the appearance of a numismatic object. Eg. Iconography, legends and physical characteristics.</rdfs:comment>
+        <rdfs:label>hasAppearance</rdfs:label>
+        <skos:definition xml:lang="en">Describes the appearance of a numismatic object. Eg. Iconography, legends and physical characteristics.</skos:definition>
+    </rdf:Property>
+    
+
+
+    <!-- http://nomisma.org/ontology#hasAuthenticity -->
+
+    <rdf:Property rdf:about="http://nomisma.org/ontology#hasAuthenticity">
+        <rdfs:comment xml:lang="en">Identifies whether a numismatic object was produced by an authority that had the relevant rights to do so, or is a contemporary or modern imitation.</rdfs:comment>
+        <rdfs:label>hasAuthenticity</rdfs:label>
+        <skos:definition xml:lang="en">Identifies whether a numismatic object was produced by an authority that had the relevant rights to do so, or is a contemporary or modern imitation.</skos:definition>
+    </rdf:Property>
+    
+
+
+    <!-- http://nomisma.org/ontology#hasAuthority -->
+
+    <rdf:Property rdf:about="http://nomisma.org/ontology#hasAuthority">
+        <rdfs:comment xml:lang="en">Identifies the authority in whose name (explicitly or implicitly) a numismatic object was issued. Eg. Charlemagne, Augustus, Sparta, Federal Republic of Germany, Bank of England</rdfs:comment>
+        <rdfs:label>hasAuthority</rdfs:label>
+        <skos:definition xml:lang="en">Identifies the authority in whose name (explicitly or implicitly) a numismatic object was issued. Eg. Charlemagne, Augustus, Sparta, Federal Republic of Germany, Bank of England</skos:definition>
+    </rdf:Property>
+    
+
+
+    <!-- http://nomisma.org/ontology#hasAxis -->
+
+    <rdf:Property rdf:about="http://nomisma.org/ontology#hasAxis">
+        <rdfs:subPropertyOf rdf:resource="http://nomisma.org/ontology#hasAppearance"/>
+        <rdfs:comment xml:lang="en">Describes the directional relationship between the obverse and reverse of a numismatic object.</rdfs:comment>
+        <rdfs:label>hasAxis</rdfs:label>
+        <skos:definition xml:lang="en">Describes the directional relationship between the obverse and reverse of a numismatic object.</skos:definition>
+    </rdf:Property>
+    
+
+
+    <!-- http://nomisma.org/ontology#hasBearsDate -->
+
+    <rdf:Property rdf:about="http://nomisma.org/ontology#hasBearsDate">
+        <rdfs:subPropertyOf rdf:resource="http://nomisma.org/ontology#hasAppearance"/>
+        <rdfs:comment xml:lang="en">Describes a date that appears on an object</rdfs:comment>
+        <rdfs:label>hasBearsDate</rdfs:label>
+        <skos:definition xml:lang="en">Describes a date that appears on an object</skos:definition>
+    </rdf:Property>
+    
+
+
+    <!-- http://nomisma.org/ontology#hasClosingDate -->
+
+    <rdf:Property rdf:about="http://nomisma.org/ontology#hasClosingDate">
+        <rdfs:subPropertyOf rdf:resource="http://nomisma.org/ontology#hasDate"/>
+        <rdfs:comment xml:lang="en">The date of the latest object (could be non-numismatic) of a given context, e.g. a hoard or layer.</rdfs:comment>
+        <rdfs:label>hasClosingDate</rdfs:label>
+        <skos:definition xml:lang="en">The date of the latest object (could be non-numismatic) of a given context, e.g. a hoard or layer.</skos:definition>
+    </rdf:Property>
+    
+
+
+    <!-- http://nomisma.org/ontology#hasCollection -->
+
+    <rdf:Property rdf:about="http://nomisma.org/ontology#hasCollection">
+        <rdfs:comment xml:lang="en">Identifies the modern collection or repository in which a numismatic object resides or has resided in the past.</rdfs:comment>
+        <rdfs:label>hasCollection</rdfs:label>
+        <skos:definition xml:lang="en">Identifies the modern collection or repository in which a numismatic object resides or has resided in the past.</skos:definition>
+    </rdf:Property>
+    
+
+
+    <!-- http://nomisma.org/ontology#hasContemporaryName -->
+
+    <rdf:Property rdf:about="http://nomisma.org/ontology#hasContemporaryName">
+        <rdfs:subPropertyOf rdf:resource="http://purl.org/dc/terms/alternative"/>
+        <rdfs:comment xml:lang="en">A contemporary name is a term for a particular group of numismatic objects or concept(s)  that was used for them at the time of their use. This may, for example, include one or more denominations, numismatic objects of a particular origin or some other common characteristic. Examples: Poloi, Tournois, Spagürli, Etschkreuzer, F-Schilling, Popolino.</rdfs:comment>
+        <rdfs:label>hasContemporaryName</rdfs:label>
+        <skos:definition xml:lang="en">A contemporary name is a term for a particular group of numismatic objects or concept(s)  that was used for them at the time of their use. This may, for example, include one or more denominations, numismatic objects of a particular origin or some other common characteristic. Examples: Poloi, Tournois, Spagürli, Etschkreuzer, F-Schilling, Popolino.</skos:definition>
+    </rdf:Property>
+    
+
+
+    <!-- http://nomisma.org/ontology#hasContext -->
+
+    <rdf:Property rdf:about="http://nomisma.org/ontology#hasContext">
+        <rdfs:comment xml:lang="en">Describes the context of a numismatic object.</rdfs:comment>
+        <rdfs:label>hasContext</rdfs:label>
+        <skos:definition xml:lang="en">Describes the context of a numismatic object.</skos:definition>
+    </rdf:Property>
+    
+
+
+    <!-- http://nomisma.org/ontology#hasControlmark -->
+
+    <rdf:Property rdf:about="http://nomisma.org/ontology#hasControlmark">
+        <rdfs:subPropertyOf rdf:resource="http://nomisma.org/ontology#hasMark"/>
+        <rdfs:comment xml:lang="en">Identifies a letter, symbol, monogram or an inscription on a numismatic object intended to distinguish it as part of a group of numismatic objects within an issue or series.</rdfs:comment>
+        <rdfs:label>hasControlmark</rdfs:label>
+        <skos:definition xml:lang="en">Identifies a letter, symbol, monogram or an inscription on a numismatic object intended to distinguish it as part of a group of numismatic objects within an issue or series.</skos:definition>
+    </rdf:Property>
+    
+
+
+    <!-- http://nomisma.org/ontology#hasCorrosion -->
+
+    <rdf:Property rdf:about="http://nomisma.org/ontology#hasCorrosion">
+        <rdfs:comment xml:lang="en">Describes degradation due to chemical reaction with an environment, commonly in terms prescribed by &quot;Abnutzung und Korrosion: Bestimmmungstafeln zur Bearbeitung von Fundmünzen = Usure et corrosion. (1995). Lausanne.&quot; (OCLC 174260520)</rdfs:comment>
+        <rdfs:label>hasCorrosion</rdfs:label>
+        <skos:definition xml:lang="en">Describes degradation due to chemical reaction with an environment, commonly in terms prescribed by &quot;Abnutzung und Korrosion: Bestimmmungstafeln zur Bearbeitung von Fundmünzen = Usure et corrosion. (1995). Lausanne.&quot; (OCLC 174260520)</skos:definition>
+    </rdf:Property>
+    
+
+
+    <!-- http://nomisma.org/ontology#hasCountermark -->
+
+    <rdf:Property rdf:about="http://nomisma.org/ontology#hasCountermark">
+        <rdfs:subPropertyOf rdf:resource="http://nomisma.org/ontology#hasIconography"/>
+        <rdfs:subPropertyOf rdf:resource="http://nomisma.org/ontology#hasSecondaryTreatment"/>
+        <rdfs:comment xml:lang="en">Identifies a mark or symbol punched into a coin or similar object  at some point during its time in circulation.</rdfs:comment>
+        <rdfs:label>hasCountermark</rdfs:label>
+        <skos:definition xml:lang="en">Identifies a mark or symbol punched into a coin or similar object  at some point during its time in circulation.</skos:definition>
+    </rdf:Property>
+    
+
+
+    <!-- http://nomisma.org/ontology#hasDate -->
+
+    <rdf:Property rdf:about="http://nomisma.org/ontology#hasDate">
+        <rdfs:comment xml:lang="en">Describes date (range) assigned in a numismatic context.</rdfs:comment>
+        <rdfs:label>hasDate</rdfs:label>
+        <skos:definition xml:lang="en">Describes date (range) assigned in a numismatic context.</skos:definition>
+    </rdf:Property>
+    
+
+
+    <!-- http://nomisma.org/ontology#hasDenomination -->
+
+    <rdf:Property rdf:about="http://nomisma.org/ontology#hasDenomination">
+        <rdfs:comment xml:lang="en">Describes the monetary value assigned to an object within a denominational system. Examples: tetradrachm, chalkous, denarius.</rdfs:comment>
+        <rdfs:label>hasDenomination</rdfs:label>
+        <skos:definition xml:lang="en">Describes the monetary value assigned to an object within a denominational system. Examples: tetradrachm, chalkous, denarius.</skos:definition>
+    </rdf:Property>
+    
+
+
+    <!-- http://nomisma.org/ontology#hasDepth -->
+
+    <rdf:Property rdf:about="http://nomisma.org/ontology#hasDepth">
+        <rdfs:subPropertyOf rdf:resource="http://nomisma.org/ontology#hasMeasurement"/>
+        <rdfs:comment xml:lang="en">Describes the depth of an object.</rdfs:comment>
+        <rdfs:label>hasDepth</rdfs:label>
+        <skos:definition xml:lang="en">Describes the depth of an object.</skos:definition>
+    </rdf:Property>
+    
+
+
+    <!-- http://nomisma.org/ontology#hasDiameter -->
+
+    <rdf:Property rdf:about="http://nomisma.org/ontology#hasDiameter">
+        <rdfs:subPropertyOf rdf:resource="http://nomisma.org/ontology#hasMeasurement"/>
+        <rdfs:comment xml:lang="en">Describes diameter of an object.</rdfs:comment>
+        <rdfs:label>hasDiameter</rdfs:label>
+        <skos:definition xml:lang="en">Describes diameter of an object.</skos:definition>
+    </rdf:Property>
+    
+
+
+    <!-- http://nomisma.org/ontology#hasDie -->
+
+    <rdf:Property rdf:about="http://nomisma.org/ontology#hasDie">
+        <rdfs:subPropertyOf rdf:resource="http://nomisma.org/ontology#hasProductionObject"/>
+        <rdfs:comment xml:lang="en">Describes the die from which a numismatic object has been produced.</rdfs:comment>
+        <rdfs:label>hasDie</rdfs:label>
+        <skos:definition xml:lang="en">Describes the die from which a numismatic object has been produced.</skos:definition>
+    </rdf:Property>
+    
+
+
+    <!-- http://nomisma.org/ontology#hasEdge -->
+
+    <rdf:Property rdf:about="http://nomisma.org/ontology#hasEdge">
+        <rdfs:subPropertyOf rdf:resource="http://nomisma.org/ontology#hasAppearance"/>
+        <rdfs:comment xml:lang="en">Describes characteristics of the edge of a numismatic object.</rdfs:comment>
+        <rdfs:label>hasEdge</rdfs:label>
+        <skos:definition xml:lang="en">Describes characteristics of the edge of a numismatic object.</skos:definition>
+    </rdf:Property>
+    
+
+
+    <!-- http://nomisma.org/ontology#hasEndDate -->
+
+    <rdf:Property rdf:about="http://nomisma.org/ontology#hasEndDate">
+        <rdfs:subPropertyOf rdf:resource="http://nomisma.org/ontology#hasDate"/>
+        <rdfs:comment xml:lang="en">Identifies the final date in a range assigned in a numismatic context.</rdfs:comment>
+        <rdfs:label>hasEndDate</rdfs:label>
+        <skos:definition xml:lang="en">Identifies the final date in a range assigned in a numismatic context.</skos:definition>
+    </rdf:Property>
+    
+
+
+    <!-- http://nomisma.org/ontology#hasFace -->
+
+    <rdf:Property rdf:about="http://nomisma.org/ontology#hasFace">
+        <rdfs:subPropertyOf rdf:resource="http://nomisma.org/ontology#hasAppearance"/>
+        <rdfs:comment xml:lang="en">Identifies a particular face of a numismatic object. Where possible and appropriate, the more specific properties hasObverse or hasReverse are preferred.</rdfs:comment>
+        <rdfs:label>hasFace</rdfs:label>
+        <skos:definition xml:lang="en">Identifies a particular face of a numismatic object. Where possible and appropriate, the more specific properties hasObverse or hasReverse are preferred.</skos:definition>
+    </rdf:Property>
+    
+
+
+    <!-- http://nomisma.org/ontology#hasFindContext -->
+
+    <rdf:Property rdf:about="http://nomisma.org/ontology#hasFindContext">
+        <rdfs:subPropertyOf rdf:resource="http://nomisma.org/ontology#hasContext"/>
+        <rdfs:comment xml:lang="en">Describes the context regarding the discovery/find of a numismatic object.</rdfs:comment>
+        <rdfs:label>hasFindContext</rdfs:label>
+        <skos:definition xml:lang="en">Describes the context regarding the discovery/find of a numismatic object.</skos:definition>
+    </rdf:Property>
+    
+
+
+    <!-- http://nomisma.org/ontology#hasFindType -->
+
+    <rdf:Property rdf:about="http://nomisma.org/ontology#hasFindType">
+        <rdfs:label>hasFindType</rdfs:label>
+        <owl:deprecated>deprecated - please use nmo:hasContext instead, together with the class Context or its sub classes: Find, DepositionType and DiscoveryType</owl:deprecated>
+        <skos:definition xml:lang="en">Describes the nature of and archaeological or other find. E.g. hoard, ritual deposit, single find, find in survey.</skos:definition>
+    </rdf:Property>
+    
+
+
+    <!-- http://nomisma.org/ontology#hasFindspot -->
+
+    <rdf:Property rdf:about="http://nomisma.org/ontology#hasFindspot">
+        <rdfs:subPropertyOf rdf:resource="http://nomisma.org/ontology#hasFindContext"/>
+        <rdfs:comment xml:lang="en">Describes the location of the discovery of an object, whether by accident or in archaeological excavation.</rdfs:comment>
+        <rdfs:label>hasFindspot</rdfs:label>
+        <skos:definition xml:lang="en">Describes the location of the discovery of an object, whether by accident or in archaeological excavation.</skos:definition>
+    </rdf:Property>
+    
+
+
+    <!-- http://nomisma.org/ontology#hasHeight -->
+
+    <rdf:Property rdf:about="http://nomisma.org/ontology#hasHeight">
+        <rdfs:subPropertyOf rdf:resource="http://nomisma.org/ontology#hasMeasurement"/>
+        <rdfs:comment xml:lang="en">Describes the height of a numismatic object.</rdfs:comment>
+        <rdfs:label>hasHeight</rdfs:label>
+        <skos:definition xml:lang="en">Describes the height of a numismatic object.</skos:definition>
+    </rdf:Property>
+    
+
+
+    <!-- http://nomisma.org/ontology#hasIconography -->
+
+    <rdf:Property rdf:about="http://nomisma.org/ontology#hasIconography">
+        <rdfs:subPropertyOf rdf:resource="http://nomisma.org/ontology#hasAppearance"/>
+        <rdfs:comment xml:lang="en">Describes an iconography placed on a numismatic object.</rdfs:comment>
+        <rdfs:label>hasIconography</rdfs:label>
+        <skos:definition xml:lang="en">Describes an iconography placed on a numismatic object.</skos:definition>
+    </rdf:Property>
+    
+
+
+    <!-- http://nomisma.org/ontology#hasImmediateContext -->
+
+    <rdf:Property rdf:about="http://nomisma.org/ontology#hasImmediateContext">
+        <rdfs:subPropertyOf rdf:resource="http://nomisma.org/ontology#hasFindContext"/>
+        <rdfs:comment xml:lang="en">Is the precise context of the findspot such as under the hearth, in the wall, under the floor, in a ditch, on a river bed, etc.</rdfs:comment>
+        <rdfs:label>hasImmediateContext</rdfs:label>
+        <skos:definition xml:lang="en">Is the precise context of the findspot such as under the hearth, in the wall, under the floor, in a ditch, on a river bed, etc.</skos:definition>
+    </rdf:Property>
+    
+
+
+    <!-- http://nomisma.org/ontology#hasIssuer -->
+
+    <rdf:Property rdf:about="http://nomisma.org/ontology#hasIssuer">
+        <rdfs:comment xml:lang="en">Identifies the person administratively responsible for the issue of a numismatic object, generally named in some capacity on the object.</rdfs:comment>
+        <rdfs:label>hasIssuer</rdfs:label>
+        <skos:definition xml:lang="en">Identifies the person administratively responsible for the issue of a numismatic object, generally named in some capacity on the object.</skos:definition>
+    </rdf:Property>
+    
+
+
+    <!-- http://nomisma.org/ontology#hasLandscapeContext -->
+
+    <rdf:Property rdf:about="http://nomisma.org/ontology#hasLandscapeContext">
+        <rdfs:subPropertyOf rdf:resource="http://nomisma.org/ontology#hasFindContext"/>
+        <rdfs:comment xml:lang="en">Is the broad scale findspot landscape type such as: urban, rural, underwater (as instances of nmo:Context in the ID namespace).</rdfs:comment>
+        <rdfs:label>hasLandscapeContext</rdfs:label>
+        <skos:definition xml:lang="en">Is the broad scale findspot landscape type such as: urban, rural, underwater (as instances of nmo:Context in the ID namespace).</skos:definition>
+    </rdf:Property>
+    
+
+
+    <!-- http://nomisma.org/ontology#hasLegend -->
+
+    <rdf:Property rdf:about="http://nomisma.org/ontology#hasLegend">
+        <rdfs:subPropertyOf rdf:resource="http://nomisma.org/ontology#hasAppearance"/>
+        <rdfs:comment xml:lang="en">Describes the inscription or printing placed on a numismatic object as part of the production process.</rdfs:comment>
+        <rdfs:label>hasLegend</rdfs:label>
+        <skos:definition xml:lang="en">Describes the inscription or printing placed on a numismatic object as part of the production process.</skos:definition>
+    </rdf:Property>
+    
+
+
+    <!-- http://nomisma.org/ontology#hasLocalContext -->
+
+    <rdf:Property rdf:about="http://nomisma.org/ontology#hasLocalContext">
+        <rdfs:subPropertyOf rdf:resource="http://nomisma.org/ontology#hasFindContext"/>
+        <rdfs:comment xml:lang="en">Is the findspot in relation to nearby features such as: from a field, in a temple, in an otherwise unspecified structure, in a shipwreck.</rdfs:comment>
+        <rdfs:label>hasLocalContext</rdfs:label>
+        <skos:definition xml:lang="en">Is the findspot in relation to nearby features such as: from a field, in a temple, in an otherwise unspecified structure, in a shipwreck.</skos:definition>
+    </rdf:Property>
+    
+
+
+    <!-- http://nomisma.org/ontology#hasManufacture -->
+
+    <rdf:Property rdf:about="http://nomisma.org/ontology#hasManufacture">
+        <rdfs:comment xml:lang="en">Describes the method of manufacture of a numismatic object. Eg. struck, cast, printed</rdfs:comment>
+        <rdfs:label>hasManufacture</rdfs:label>
+        <skos:definition xml:lang="en">Describes the method of manufacture of a numismatic object. Eg. struck, cast, printed</skos:definition>
+    </rdf:Property>
+    
+
+
+    <!-- http://nomisma.org/ontology#hasMark -->
+
+    <rdf:Property rdf:about="http://nomisma.org/ontology#hasMark">
+        <rdfs:subPropertyOf rdf:resource="http://nomisma.org/ontology#hasAppearance"/>
+        <rdfs:comment xml:lang="en">Any kind of mark, e.g. a character, letter, symbol or an inscription on a numismatic object. No intension for the mark is predefined by this property. It could be a mark generated during production or as a secondary treatment.</rdfs:comment>
+        <rdfs:label>hasMark</rdfs:label>
+        <skos:definition xml:lang="en">Any kind of mark, e.g. a character, letter, symbol or an inscription on a numismatic object. No intension for the mark is predefined by this property. It could be a mark generated during production or as a secondary treatment.</skos:definition>
+    </rdf:Property>
+    
+
+
+    <!-- http://nomisma.org/ontology#hasMaterial -->
+
+    <rdf:Property rdf:about="http://nomisma.org/ontology#hasMaterial">
+        <rdfs:subPropertyOf rdf:resource="http://www.w3.org/2002/07/owl#topObjectProperty"/>
+        <rdfs:comment xml:lang="en">Describes the physical material from which a numismatic object is made.</rdfs:comment>
+        <rdfs:label>hasMaterial</rdfs:label>
+        <skos:definition xml:lang="en">Describes the physical material from which a numismatic object is made.</skos:definition>
+    </rdf:Property>
+    
+
+
+    <!-- http://nomisma.org/ontology#hasMaxDepth -->
+
+    <rdf:Property rdf:about="http://nomisma.org/ontology#hasMaxDepth">
+        <rdfs:subPropertyOf rdf:resource="http://nomisma.org/ontology#hasDepth"/>
+        <rdfs:comment xml:lang="en">Describes the maximum depth of a numismatic object.</rdfs:comment>
+        <rdfs:label>hasMaxDepth</rdfs:label>
+        <skos:definition xml:lang="en">Describes the maximum depth of a numismatic object.</skos:definition>
+    </rdf:Property>
+    
+
+
+    <!-- http://nomisma.org/ontology#hasMaxDiameter -->
+
+    <rdf:Property rdf:about="http://nomisma.org/ontology#hasMaxDiameter">
+        <rdfs:subPropertyOf rdf:resource="http://nomisma.org/ontology#hasDiameter"/>
+        <rdfs:comment xml:lang="en">Describes the maximum diameter of a numismatic object.</rdfs:comment>
+        <rdfs:label>hasMaxDiameter</rdfs:label>
+        <skos:definition xml:lang="en">Describes the maximum diameter of a numismatic object.</skos:definition>
+    </rdf:Property>
+    
+
+
+    <!-- http://nomisma.org/ontology#hasMaxHeight -->
+
+    <rdf:Property rdf:about="http://nomisma.org/ontology#hasMaxHeight">
+        <rdfs:subPropertyOf rdf:resource="http://nomisma.org/ontology#hasHeight"/>
+        <rdfs:comment xml:lang="en">Describes the maximum height of a numismatic object.</rdfs:comment>
+        <rdfs:label>hasMaxHeight</rdfs:label>
+        <skos:definition xml:lang="en">Describes the maximum height of a numismatic object.</skos:definition>
+    </rdf:Property>
+    
+
+
+    <!-- http://nomisma.org/ontology#hasMaxWidth -->
+
+    <rdf:Property rdf:about="http://nomisma.org/ontology#hasMaxWidth">
+        <rdfs:subPropertyOf rdf:resource="http://nomisma.org/ontology#hasWidth"/>
+        <rdfs:comment xml:lang="en">Describes the maximum width of a numismatic object.</rdfs:comment>
+        <rdfs:label>hasMaxWidth</rdfs:label>
+        <skos:definition xml:lang="en">Describes the maximum width of a numismatic object.</skos:definition>
+    </rdf:Property>
+    
+
+
+    <!-- http://nomisma.org/ontology#hasMeasurement -->
+
+    <rdf:Property rdf:about="http://nomisma.org/ontology#hasMeasurement">
+        <rdfs:comment xml:lang="en">Introduced for better structuring of subproperties like nmo:hasWidth, nmo:hasHeight ... not intended to be used directly. (abstract)</rdfs:comment>
+        <rdfs:label>hasMeasurement</rdfs:label>
+        <skos:definition xml:lang="en">Introduced for better structuring of subproperties like nmo:hasWidth, nmo:hasHeight ... not intended to be used directly. (abstract)</skos:definition>
+    </rdf:Property>
+    
+
+
+    <!-- http://nomisma.org/ontology#hasMinDepth -->
+
+    <rdf:Property rdf:about="http://nomisma.org/ontology#hasMinDepth">
+        <rdfs:subPropertyOf rdf:resource="http://nomisma.org/ontology#hasDepth"/>
+        <rdfs:comment xml:lang="en">Describes the minimum depth of a numismatic object.</rdfs:comment>
+        <rdfs:label>hasMinDepth</rdfs:label>
+        <skos:definition xml:lang="en">Describes the minimum depth of a numismatic object.</skos:definition>
+    </rdf:Property>
+    
+
+
+    <!-- http://nomisma.org/ontology#hasMinDiameter -->
+
+    <rdf:Property rdf:about="http://nomisma.org/ontology#hasMinDiameter">
+        <rdfs:subPropertyOf rdf:resource="http://nomisma.org/ontology#hasDiameter"/>
+        <rdfs:comment xml:lang="en">Describes the minimum diameter of a numismatic object.</rdfs:comment>
+        <rdfs:label>hasMinDiameter</rdfs:label>
+        <skos:definition xml:lang="en">Describes the minimum diameter of a numismatic object.</skos:definition>
+    </rdf:Property>
+    
+
+
+    <!-- http://nomisma.org/ontology#hasMinHeight -->
+
+    <rdf:Property rdf:about="http://nomisma.org/ontology#hasMinHeight">
+        <rdfs:subPropertyOf rdf:resource="http://nomisma.org/ontology#hasHeight"/>
+        <rdfs:comment xml:lang="en">Describes the minimum height of a numismatic object.</rdfs:comment>
+        <rdfs:label>hasMinHeight</rdfs:label>
+        <skos:definition xml:lang="en">Describes the minimum height of a numismatic object.</skos:definition>
+    </rdf:Property>
+    
+
+
+    <!-- http://nomisma.org/ontology#hasMinWidth -->
+
+    <rdf:Property rdf:about="http://nomisma.org/ontology#hasMinWidth">
+        <rdfs:subPropertyOf rdf:resource="http://nomisma.org/ontology#hasWidth"/>
+        <rdfs:comment xml:lang="en">Describes the minimum width of a numismatic object.</rdfs:comment>
+        <rdfs:label>hasMinWidth</rdfs:label>
+        <skos:definition xml:lang="en">Describes the minimum width of a numismatic object.</skos:definition>
+    </rdf:Property>
+    
+
+
+    <!-- http://nomisma.org/ontology#hasMint -->
+
+    <rdf:Property rdf:about="http://nomisma.org/ontology#hasMint">
+        <rdfs:comment xml:lang="en">Identifies the place of manufacture or issue of a numismatic object.</rdfs:comment>
+        <rdfs:label>hasMint</rdfs:label>
+        <skos:definition xml:lang="en">Identifies the place of manufacture or issue of a numismatic object.</skos:definition>
+    </rdf:Property>
+    
+
+
+    <!-- http://nomisma.org/ontology#hasMintmark -->
+
+    <rdf:Property rdf:about="http://nomisma.org/ontology#hasMintmark">
+        <rdfs:subPropertyOf rdf:resource="http://nomisma.org/ontology#hasControlmark"/>
+        <rdfs:comment xml:lang="en">Identifies the letter, symbol or an inscription on a numismatic object indicating the mint where it was produced.</rdfs:comment>
+        <rdfs:label>hasMintmark</rdfs:label>
+        <skos:definition xml:lang="en">Identifies the letter, symbol or an inscription on a numismatic object indicating the mint where it was produced.</skos:definition>
+    </rdf:Property>
+    
+
+
+    <!-- http://nomisma.org/ontology#hasNumismaticClosingDate -->
+
+    <rdf:Property rdf:about="http://nomisma.org/ontology#hasNumismaticClosingDate">
+        <rdfs:subPropertyOf rdf:resource="http://nomisma.org/ontology#hasDate"/>
+        <rdfs:comment xml:lang="en">The date of the latest numismatic object of a given context, e.g. a hoard or layer.</rdfs:comment>
+        <rdfs:label>hasNumismaticClosingDate</rdfs:label>
+        <skos:definition xml:lang="en">The date of the latest numismatic object of a given context, e.g. a hoard or layer.</skos:definition>
+    </rdf:Property>
+    
+
+
+    <!-- http://nomisma.org/ontology#hasNumismaticOpeningDate -->
+
+    <rdf:Property rdf:about="http://nomisma.org/ontology#hasNumismaticOpeningDate">
+        <rdfs:subPropertyOf rdf:resource="http://nomisma.org/ontology#hasDate"/>
+        <rdfs:comment xml:lang="en">The date of the earliest numismatic object of a given context, e.g. a hoard or layer.</rdfs:comment>
+        <rdfs:label>hasNumismaticOpeningDate</rdfs:label>
+        <skos:definition xml:lang="en">The date of the earliest numismatic object of a given context, e.g. a hoard or layer.</skos:definition>
+    </rdf:Property>
+    
+
+
+    <!-- http://nomisma.org/ontology#hasObjectType -->
+
+    <rdf:Property rdf:about="http://nomisma.org/ontology#hasObjectType">
+        <rdfs:comment xml:lang="en">Identifies the type of numismatic object. E.g. Coin, token, banknote.</rdfs:comment>
+        <rdfs:label>hasObjectType</rdfs:label>
+        <skos:definition xml:lang="en">Identifies the type of numismatic object. E.g. Coin, token, banknote.</skos:definition>
+    </rdf:Property>
+    
+
+
+    <!-- http://nomisma.org/ontology#hasObverse -->
+
+    <rdf:Property rdf:about="http://nomisma.org/ontology#hasObverse">
+        <rdfs:subPropertyOf rdf:resource="http://nomisma.org/ontology#hasFace"/>
+        <rdfs:comment xml:lang="en">Identifies a particular face of a numismatic object. Normally it will be the face carrying the represenation, badge or inscription of the issuing authority. In ancient, hand-struck coinage it is generally the lower (anvil) die. In English often known as &quot;heads&quot;.</rdfs:comment>
+        <rdfs:label>hasObverse</rdfs:label>
+        <skos:definition xml:lang="en">Identifies a particular face of a numismatic object. Normally it will be the face carrying the represenation, badge or inscription of the issuing authority. In ancient, hand-struck coinage it is generally the lower (anvil) die. In English often known as &quot;heads&quot;.</skos:definition>
+    </rdf:Property>
+    
+
+
+    <!-- http://nomisma.org/ontology#hasOpeningDate -->
+
+    <rdf:Property rdf:about="http://nomisma.org/ontology#hasOpeningDate">
+        <rdfs:subPropertyOf rdf:resource="http://nomisma.org/ontology#hasDate"/>
+        <rdfs:comment xml:lang="en">The date of the earliest object (could be non-numismatic) of a given context, e.g. a hoard or layer.</rdfs:comment>
+        <rdfs:label>hasOpeningDate</rdfs:label>
+        <skos:definition xml:lang="en">The date of the earliest object (could be non-numismatic) of a given context, e.g. a hoard or layer.</skos:definition>
+    </rdf:Property>
+    
+
+
+    <!-- http://nomisma.org/ontology#hasPeculiarity -->
+
+    <rdf:Property rdf:about="http://nomisma.org/ontology#hasPeculiarity">
+        <rdfs:comment xml:lang="en">Describes a notable, characteristic or unusual physical feature of an individual numismatic object marks it out from other examples of the same group, or of a group of numismatic objects that marks it out from other groups. It can be the result of production, such as plating, or post-production activity, such as piercing, cutting or mounting.</rdfs:comment>
+        <rdfs:label>hasPeculiarity</rdfs:label>
+        <skos:definition xml:lang="en">Describes a notable, characteristic or unusual physical feature of an individual numismatic object marks it out from other examples of the same group, or of a group of numismatic objects that marks it out from other groups. It can be the result of production, such as plating, or post-production activity, such as piercing, cutting or mounting.</skos:definition>
+    </rdf:Property>
+    
+
+
+    <!-- http://nomisma.org/ontology#hasPeculiarityOfProduction -->
+
+    <rdf:Property rdf:about="http://nomisma.org/ontology#hasPeculiarityOfProduction">
+        <rdfs:subPropertyOf rdf:resource="http://nomisma.org/ontology#hasPeculiarity"/>
+        <rdfs:comment xml:lang="en">Describes a notable, characteristic or unusual physical feature of an individual numismatic object which distinguishes it from other examples of the same group, or of a group of numismatic objects that marks it out from other groups, and which is related to the process of production of a numismatic object.</rdfs:comment>
+        <rdfs:label>hasPeculiarityOfProduction</rdfs:label>
+        <skos:definition xml:lang="en">Describes a notable, characteristic or unusual physical feature of an individual numismatic object which distinguishes it from other examples of the same group, or of a group of numismatic objects that marks it out from other groups, and which is related to the process of production of a numismatic object.</skos:definition>
+    </rdf:Property>
+    
+
+
+    <!-- http://nomisma.org/ontology#hasPortrait -->
+
+    <rdf:Property rdf:about="http://nomisma.org/ontology#hasPortrait">
+        <rdfs:subPropertyOf rdf:resource="http://nomisma.org/ontology#hasIconography"/>
+        <rdfs:label>hasPortrait</rdfs:label>
+        <skos:definition xml:lang="en">Identifies the person whose portrait appears on a numismatic object.</skos:definition>
+    </rdf:Property>
+    
+
+
+    <!-- http://nomisma.org/ontology#hasProductionDate -->
+
+    <rdf:Property rdf:about="http://nomisma.org/ontology#hasProductionDate">
+        <rdfs:subPropertyOf rdf:resource="http://nomisma.org/ontology#hasDate"/>
+        <rdfs:comment xml:lang="en">Describes the date (range) of the production of a numismatic object.</rdfs:comment>
+        <rdfs:label>hasProductionDate</rdfs:label>
+        <skos:definition xml:lang="en">Describes the date (range) of the production of a numismatic object.</skos:definition>
+    </rdf:Property>
+    
+
+
+    <!-- http://nomisma.org/ontology#hasProductionObject -->
+
+    <rdf:Property rdf:about="http://nomisma.org/ontology#hasProductionObject">
+        <rdfs:comment xml:lang="en">Objects used within the production process.</rdfs:comment>
+        <rdfs:label>hasProductionObject</rdfs:label>
+        <skos:definition xml:lang="en">Objects used within the production process.</skos:definition>
+    </rdf:Property>
+    
+
+
+    <!-- http://nomisma.org/ontology#hasReferenceWork -->
+
+    <rdf:Property rdf:about="http://nomisma.org/ontology#hasReferenceWork">
+        <rdfs:comment xml:lang="en">Specifies a published work of reference relevant to a numismatic object.</rdfs:comment>
+        <rdfs:label>hasReferenceWork</rdfs:label>
+        <skos:definition xml:lang="en">Specifies a published work of reference relevant to a numismatic object.</skos:definition>
+    </rdf:Property>
+    
+
+
+    <!-- http://nomisma.org/ontology#hasReverse -->
+
+    <rdf:Property rdf:about="http://nomisma.org/ontology#hasReverse">
+        <rdfs:subPropertyOf rdf:resource="http://nomisma.org/ontology#hasFace"/>
+        <rdfs:comment xml:lang="en">Identifies a the face of a numismatic object opposed to the obverse. In ancient, hand-struck coinage it is generally the upper die. In English often known as &quot;tails&quot;.</rdfs:comment>
+        <rdfs:label>hasReverse</rdfs:label>
+        <skos:definition xml:lang="en">Identifies a the face of a numismatic object opposed to the obverse. In ancient, hand-struck coinage it is generally the upper die. In English often known as &quot;tails&quot;.</skos:definition>
+    </rdf:Property>
+    
+
+
+    <!-- http://nomisma.org/ontology#hasScholarlyName -->
+
+    <rdf:Property rdf:about="http://nomisma.org/ontology#hasScholarlyName">
+        <rdfs:subPropertyOf rdf:resource="http://purl.org/dc/terms/alternative"/>
+        <rdfs:comment xml:lang="en">A scholarly name is a term for a particular group of numismatic objects  or concept(s)  that was established after the time of their use, as part of scholarly jargon. Examples: Croeseid, Schneckentaler, Falkendukat, Antoninianus.</rdfs:comment>
+        <rdfs:label>hasScholarlyName</rdfs:label>
+        <skos:definition xml:lang="en">A scholarly name is a term for a particular group of numismatic objects  or concept(s)  that was established after the time of their use, as part of scholarly jargon. Examples: Croeseid, Schneckentaler, Falkendukat, Antoninianus.</skos:definition>
+    </rdf:Property>
+    
+
+
+    <!-- http://nomisma.org/ontology#hasSecondaryTreatment -->
+
+    <rdf:Property rdf:about="http://nomisma.org/ontology#hasSecondaryTreatment">
+        <rdfs:subPropertyOf rdf:resource="http://nomisma.org/ontology#hasPeculiarity"/>
+        <rdfs:comment xml:lang="en">Describes anomalies or unusual features which arise subsequent to the actual production of a numismatic object; for example halving, chop-marking, etc.</rdfs:comment>
+        <rdfs:label>hasSecondaryTreatment</rdfs:label>
+        <skos:definition xml:lang="en">Describes anomalies or unusual features which arise subsequent to the actual production of a numismatic object; for example halving, chop-marking, etc.</skos:definition>
+    </rdf:Property>
+    
+
+
+    <!-- http://nomisma.org/ontology#hasShape -->
+
+    <rdf:Property rdf:about="http://nomisma.org/ontology#hasShape">
+        <rdfs:subPropertyOf rdf:resource="http://nomisma.org/ontology#hasAppearance"/>
+        <rdfs:comment xml:lang="en">Describes the shape of a numismatic object.</rdfs:comment>
+        <rdfs:label>hasShape</rdfs:label>
+        <skos:definition xml:lang="en">Describes the shape of a numismatic object.</skos:definition>
+    </rdf:Property>
+    
+
+
+    <!-- http://nomisma.org/ontology#hasStartDate -->
+
+    <rdf:Property rdf:about="http://nomisma.org/ontology#hasStartDate">
+        <rdfs:subPropertyOf rdf:resource="http://nomisma.org/ontology#hasDate"/>
+        <rdfs:comment xml:lang="en">Identifies the initial date in a range assigned in a numismatic context.</rdfs:comment>
+        <rdfs:label>hasStartDate</rdfs:label>
+        <skos:definition xml:lang="en">Identifies the initial date in a range assigned in a numismatic context.</skos:definition>
+    </rdf:Property>
+    
+
+
+    <!-- http://nomisma.org/ontology#hasStatedAuthority -->
+
+    <rdf:Property rdf:about="http://nomisma.org/ontology#hasStatedAuthority">
+        <rdfs:subPropertyOf rdf:resource="http://nomisma.org/ontology#hasAppearance"/>
+        <rdfs:comment xml:lang="en">The authority as stated on a numismatic object. This may, but need not, be the same as the real authority behind the object (expressed separately as hasAuthority).</rdfs:comment>
+        <rdfs:label>hasStatedAuthority</rdfs:label>
+        <skos:definition xml:lang="en">The authority as stated on a numismatic object. This may, but need not, be the same as the real authority behind the object (expressed separately as hasAuthority).</skos:definition>
+    </rdf:Property>
+    
+
+
+    <!-- http://nomisma.org/ontology#hasTypeSeriesItem -->
+
+    <rdf:Property rdf:about="http://nomisma.org/ontology#hasTypeSeriesItem">
+        <rdfs:comment xml:lang="en">Identifies the position of a numismatic object within a published or recognized reference list of types, such as a catalogue or corpus.</rdfs:comment>
+        <rdfs:label>hasTypeSeriesItem</rdfs:label>
+        <skos:definition xml:lang="en">Identifies the position of a numismatic object within a published or recognized reference list of types, such as a catalogue or corpus.</skos:definition>
+    </rdf:Property>
+    
+
+
+    <!-- http://nomisma.org/ontology#hasWear -->
+
+    <rdf:Property rdf:about="http://nomisma.org/ontology#hasWear">
+        <rdfs:comment xml:lang="en">Describes wear visible on a numismatic object due to use or circulation, commonly in terms prescribed by &quot;Abnutzung und Korrosion: Bestimmmungstafeln zur Bearbeitung von Fundmünzen = Usure et corrosion. (1995). Lausanne.&quot; (OCLC 174260520)</rdfs:comment>
+        <rdfs:label>hasWear</rdfs:label>
+        <skos:definition xml:lang="en">Describes wear visible on a numismatic object due to use or circulation, commonly in terms prescribed by &quot;Abnutzung und Korrosion: Bestimmmungstafeln zur Bearbeitung von Fundmünzen = Usure et corrosion. (1995). Lausanne.&quot; (OCLC 174260520)</skos:definition>
+    </rdf:Property>
+    
+
+
+    <!-- http://nomisma.org/ontology#hasWeight -->
+
+    <rdf:Property rdf:about="http://nomisma.org/ontology#hasWeight">
+        <rdfs:subPropertyOf rdf:resource="http://nomisma.org/ontology#hasMeasurement"/>
+        <rdfs:comment xml:lang="en">Describes the actual weight of a numismatic object.</rdfs:comment>
+        <rdfs:label>hasWeight</rdfs:label>
+        <skos:definition xml:lang="en">Describes the actual weight of a numismatic object.</skos:definition>
+    </rdf:Property>
+    
+
+
+    <!-- http://nomisma.org/ontology#hasWeightStandard -->
+
+    <rdf:Property rdf:about="http://nomisma.org/ontology#hasWeightStandard">
+        <rdfs:comment xml:lang="en">Describes the conventional weight system according to which a numismatic object of intrinsic value was produced.</rdfs:comment>
+        <rdfs:label>hasWeightStandard</rdfs:label>
+        <skos:definition xml:lang="en">Describes the conventional weight system according to which a numismatic object of intrinsic value was produced.</skos:definition>
+    </rdf:Property>
+    
+
+
+    <!-- http://nomisma.org/ontology#hasWidth -->
+
+    <rdf:Property rdf:about="http://nomisma.org/ontology#hasWidth">
+        <rdfs:subPropertyOf rdf:resource="http://nomisma.org/ontology#hasMeasurement"/>
+        <rdfs:comment xml:lang="en">Describes the width of a numismatic object.</rdfs:comment>
+        <rdfs:label>hasWidth</rdfs:label>
+        <skos:definition xml:lang="en">Describes the width of a numismatic object.</skos:definition>
+    </rdf:Property>
+    
+
+
+    <!-- http://nomisma.org/ontology#isAbove -->
+
+    <rdf:Property rdf:about="http://nomisma.org/ontology#isAbove">
+        <rdfs:subPropertyOf rdf:resource="http://nomisma.org/ontology#hasFindContext"/>
+        <owl:inverseOf rdf:resource="http://nomisma.org/ontology#isBelow"/>
+        <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#TransitiveProperty"/>
+        <rdfs:domain rdf:resource="http://nomisma.org/ontology#StratigraphicUnit"/>
+        <rdfs:range rdf:resource="http://nomisma.org/ontology#StratigraphicUnit"/>
+        <rdfs:comment xml:lang="en">Based on the Harris Matrix system for units of archaeological stratification. The subject unit is above the object unit in the relative sequence of the units of stratification through time (see: Principles of archaeological stratigraphy by Edward Harris).</rdfs:comment>
+        <rdfs:label>isAbove</rdfs:label>
+        <skos:definition xml:lang="en">Based on the Harris Matrix system for units of archaeological stratification. The subject unit is above the object unit in the relative sequence of the units of stratification through time (see: Principles of archaeological stratigraphy by Edward Harris).</skos:definition>
+    </rdf:Property>
+    
+
+
+    <!-- http://nomisma.org/ontology#isBelow -->
+
+    <rdf:Property rdf:about="http://nomisma.org/ontology#isBelow">
+        <rdfs:subPropertyOf rdf:resource="http://nomisma.org/ontology#hasFindContext"/>
+        <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#TransitiveProperty"/>
+        <rdfs:domain rdf:resource="http://nomisma.org/ontology#StratigraphicUnit"/>
+        <rdfs:range rdf:resource="http://nomisma.org/ontology#StratigraphicUnit"/>
+        <rdfs:comment xml:lang="en">Based on the Harris Matrix system for units of archaeological stratification. The subject unit is below the object in the relative sequence of the units of stratification through time (see: Principles of archaeological stratigraphy by Edward Harris).</rdfs:comment>
+        <rdfs:label xml:lang="en">isBelow</rdfs:label>
+        <skos:definition xml:lang="en">Based on the Harris Matrix system for units of archaeological stratification. The subject unit is below the object in the relative sequence of the units of stratification through time (see: Principles of archaeological stratigraphy by Edward Harris).</skos:definition>
+    </rdf:Property>
+    
+
+
+    <!-- http://nomisma.org/ontology#isEqual -->
+
+    <rdf:Property rdf:about="http://nomisma.org/ontology#isEqual">
+        <rdfs:subPropertyOf rdf:resource="http://nomisma.org/ontology#hasFindContext"/>
+        <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#SymmetricProperty"/>
+        <rdfs:domain rdf:resource="http://nomisma.org/ontology#StratigraphicUnit"/>
+        <rdfs:range rdf:resource="http://nomisma.org/ontology#StratigraphicUnit"/>
+        <rdfs:comment xml:lang="en">Based on the Harris Matrix system for units of archaeological stratification. The units are correlated (equated by the = sign) as separate parts (given different numbers in the field) of a once whole deposit or feature interface (see: Principles of archaeological stratigraphy by Edward Harris).</rdfs:comment>
+        <rdfs:label xml:lang="en">isEqual</rdfs:label>
+        <skos:definition xml:lang="en">Based on the Harris Matrix system for units of archaeological stratification. The units are correlated (equated by the = sign) as separate parts (given different numbers in the field) of a once whole deposit or feature interface (see: Principles of archaeological stratigraphy by Edward Harris).</skos:definition>
+    </rdf:Property>
+    
+
+
+    <!-- http://nomisma.org/ontology#representsObjectType -->
+
+    <rdf:Property rdf:about="http://nomisma.org/ontology#representsObjectType">
+        <rdfs:comment xml:lang="en">To indicate what kind of object type is represented by (for example) an type series item (a coin, banknote, token, ...).</rdfs:comment>
+        <rdfs:label>representsObjectType</rdfs:label>
+        <skos:definition xml:lang="en">To indicate what kind of object type is represented by (for example) an type series item (a coin, banknote, token, ...).</skos:definition>
+    </rdf:Property>
+    
+
+
+    <!-- http://nomisma.org/ontology#reproductionOf -->
+
+    <rdf:Property rdf:about="http://nomisma.org/ontology#reproductionOf">
+        <rdfs:comment xml:lang="en">Connects a reproduction of a numismatic object (to study it or to generate a surrogate – should not be used for contemporary imitations or forgeries) to its original.</rdfs:comment>
+        <rdfs:label>reproductionOf</rdfs:label>
+        <skos:definition xml:lang="en">Connects a reproduction of a numismatic object (to study it or to generate a surrogate – should not be used for contemporary imitations or forgeries) to its original.</skos:definition>
+    </rdf:Property>
+    
+
+
+    <!-- http://purl.org/dc/terms/alternative -->
+
+    <rdf:Property rdf:about="http://purl.org/dc/terms/alternative"/>
+    
+
+
+    <!-- 
+    ///////////////////////////////////////////////////////////////////////////////////////
+    //
+    // Classes
+    //
+    ///////////////////////////////////////////////////////////////////////////////////////
+     -->
+
+    
+
+
+    <!-- http://nomisma.org/ontology#Authenticity -->
+
+    <owl:Class rdf:about="http://nomisma.org/ontology#Authenticity">
+        <rdfs:comment xml:lang="en">The contemporary legal status of a numismatic object: whether it was produced by an authority that had the relevant rights to do so, or is a contemporary or modern imitation.</rdfs:comment>
+        <rdfs:label>Authenticity</rdfs:label>
+        <skos:definition xml:lang="en">The contemporary legal status of a numismatic object: whether it was produced by an authority that had the relevant rights to do so, or is a contemporary or modern imitation.</skos:definition>
+    </owl:Class>
+    
+
+
+    <!-- http://nomisma.org/ontology#CoinWear -->
+
+    <owl:Class rdf:about="http://nomisma.org/ontology#CoinWear">
+        <rdfs:subClassOf rdf:resource="http://nomisma.org/ontology#Wear"/>
+    </owl:Class>
+    
+
+
+    <!-- http://nomisma.org/ontology#Collection -->
+
+    <owl:Class rdf:about="http://nomisma.org/ontology#Collection"/>
+    
+
+
+    <!-- http://nomisma.org/ontology#Context -->
+
+    <owl:Class rdf:about="http://nomisma.org/ontology#Context">
+        <rdfs:comment xml:lang="en">The archaeological context of a numismatic object.</rdfs:comment>
+        <rdfs:label>Context</rdfs:label>
+        <skos:definition xml:lang="en">The archaeological context of a numismatic object. </skos:definition>
+    </owl:Class>
+    
+
+
+    <!-- http://nomisma.org/ontology#Controlmark -->
+
+    <owl:Class rdf:about="http://nomisma.org/ontology#Controlmark">
+        <rdfs:comment xml:lang="en">A control mark is a letter, symbol or an inscription on a numismatic object intended to distinguish a group of coins within an issue or series.</rdfs:comment>
+        <rdfs:label>Controlmark</rdfs:label>
+        <skos:definition xml:lang="en">A control mark is a letter, symbol or an inscription on a numismatic object intended to distinguish a group of coins within an issue or series.</skos:definition>
+    </owl:Class>
+    
+
+
+    <!-- http://nomisma.org/ontology#Corrosion -->
+
+    <owl:Class rdf:about="http://nomisma.org/ontology#Corrosion">
+        <rdfs:comment xml:lang="en">Degradation to a numismatic object due to chemical reaction with its environment.</rdfs:comment>
+        <rdfs:label>Corrosion</rdfs:label>
+        <skos:definition xml:lang="en">Degradation to a numismatic object due to chemical reaction with its environment.</skos:definition>
+    </owl:Class>
+    
+
+
+    <!-- http://nomisma.org/ontology#Countermark -->
+
+    <owl:Class rdf:about="http://nomisma.org/ontology#Countermark">
+        <rdfs:subClassOf rdf:resource="http://nomisma.org/ontology#SecondaryTreatment"/>
+        <rdfs:comment xml:lang="en">A mark or symbol punched into a coin or similar object at some point during its time in circulation.</rdfs:comment>
+        <rdfs:label>Countermark</rdfs:label>
+        <skos:definition xml:lang="en">A mark or symbol punched into a coin or similar object at some point during its time in circulation.</skos:definition>
+    </owl:Class>
+    
+
+
+    <!-- http://nomisma.org/ontology#Denomination -->
+
+    <owl:Class rdf:about="http://nomisma.org/ontology#Denomination"/>
+    
+
+
+    <!-- http://nomisma.org/ontology#DepositionType -->
+
+    <owl:Class rdf:about="http://nomisma.org/ontology#DepositionType">
+        <rdfs:subClassOf rdf:resource="http://nomisma.org/ontology#Context"/>
+        <rdfs:comment xml:lang="en">The circumstances under which an object or group of objects came to be deposited and part of the archaeological record, for example as a hoard, votive deposit or chance loss.</rdfs:comment>
+        <rdfs:label>DepositionType</rdfs:label>
+        <skos:definition xml:lang="en">The circumstances under which an object or group of objects came to be deposited and part of the archaeological record, for example as a hoard, votive deposit or chance loss.</skos:definition>
+    </owl:Class>
+    
+
+
+    <!-- http://nomisma.org/ontology#DieWear -->
+
+    <owl:Class rdf:about="http://nomisma.org/ontology#DieWear">
+        <rdfs:subClassOf rdf:resource="http://nomisma.org/ontology#Wear"/>
+        <rdfs:comment xml:lang="en">Wear on a die occurring as a result of its use.</rdfs:comment>
+        <rdfs:label>DieWear</rdfs:label>
+        <skos:definition xml:lang="en">Wear on a die occurring as a result of its use.</skos:definition>
+    </owl:Class>
+    
+
+
+    <!-- http://nomisma.org/ontology#DiscoveryType -->
+
+    <owl:Class rdf:about="http://nomisma.org/ontology#DiscoveryType">
+        <rdfs:subClassOf rdf:resource="http://nomisma.org/ontology#Context"/>
+        <rdfs:comment xml:lang="en">The circumstances under which an object or group of objects came to be discovered, for example as a chance stray find or a controlled excavation.</rdfs:comment>
+        <rdfs:label>DiscoveryType</rdfs:label>
+        <skos:definition xml:lang="en">The circumstances under which an object or group of objects came to be discovered, for example as a chance stray find or a controlled excavation.</skos:definition>
+    </owl:Class>
+    
+
+
+    <!-- http://nomisma.org/ontology#Ethnic -->
+
+    <owl:Class rdf:about="http://nomisma.org/ontology#Ethnic"/>
+    
+
+
+    <!-- http://nomisma.org/ontology#FieldOfNumismatics -->
+
+    <owl:Class rdf:about="http://nomisma.org/ontology#FieldOfNumismatics"/>
+    
+
+
+    <!-- http://nomisma.org/ontology#Find -->
+
+    <owl:Class rdf:about="http://nomisma.org/ontology#Find">
+        <rdfs:subClassOf rdf:resource="http://nomisma.org/ontology#Context"/>
+        <rdfs:comment xml:lang="en">A numismatic object or group of numismatic objects that was lost or deposited, whether intentionally or unintentionally, in previous times, and subsequently recovered. The recovery takes place independently of any intention of retrieval associated with the original deposition.</rdfs:comment>
+        <rdfs:label>Find</rdfs:label>
+        <skos:definition xml:lang="en">A numismatic object or group of numismatic objects that was lost or deposited, whether intentionally or unintentionally, in previous times, and subsequently recovered. The recovery takes place independently of any intention of retrieval associated with the original deposition.</skos:definition>
+    </owl:Class>
+    
+
+
+    <!-- http://nomisma.org/ontology#Hoard -->
+
+    <owl:Class rdf:about="http://nomisma.org/ontology#Hoard">
+        <rdfs:subClassOf rdf:resource="http://nomisma.org/ontology#Find"/>
+        <rdfs:comment xml:lang="en">Within nomisma this is defined as a group of objects deposited together, of which at least one is a numismatic object.</rdfs:comment>
+        <rdfs:label>Hoard</rdfs:label>
+        <skos:definition xml:lang="en">Within nomisma this is defined as a group of objects deposited together, of which at least one is a numismatic object.</skos:definition>
+    </owl:Class>
+    
+
+
+    <!-- http://nomisma.org/ontology#Manufacture -->
+
+    <owl:Class rdf:about="http://nomisma.org/ontology#Manufacture"/>
+    
+
+
+    <!-- http://nomisma.org/ontology#Material -->
+
+    <owl:Class rdf:about="http://nomisma.org/ontology#Material"/>
+    
+
+
+    <!-- http://nomisma.org/ontology#Mint -->
+
+    <owl:Class rdf:about="http://nomisma.org/ontology#Mint"/>
+    
+
+
+    <!-- http://nomisma.org/ontology#Mintmark -->
+
+    <owl:Class rdf:about="http://nomisma.org/ontology#Mintmark">
+        <rdfs:subClassOf rdf:resource="http://nomisma.org/ontology#Controlmark"/>
+        <rdfs:comment xml:lang="en">A mint mark is a letter, symbol or an inscription on a numismatic object indicating the mint where the numismatic object was produced.</rdfs:comment>
+        <rdfs:label>Mintmark</rdfs:label>
+        <skos:definition xml:lang="en">A mint mark is a letter, symbol or an inscription on a numismatic object indicating the mint where the numismatic object was produced.</skos:definition>
+    </owl:Class>
+    
+
+
+    <!-- http://nomisma.org/ontology#Monogram -->
+
+    <owl:Class rdf:about="http://nomisma.org/ontology#Monogram">
+        <rdfs:comment xml:lang="en">A monogram is a symbol made by overlapping or combining of letters or other graphemes.</rdfs:comment>
+        <rdfs:label>Monogram</rdfs:label>
+        <skos:definition xml:lang="en">A monogram is a symbol made by overlapping or combining of letters or other graphemes.</skos:definition>
+    </owl:Class>
+    
+
+
+    <!-- http://nomisma.org/ontology#NumismaticObject -->
+
+    <owl:Class rdf:about="http://nomisma.org/ontology#NumismaticObject">
+        <rdfs:comment xml:lang="en">Objects considered to be within the numismatic domain such as coins, tokens, banknotes etc.</rdfs:comment>
+        <rdfs:label>NumismaticObject</rdfs:label>
+        <skos:definition xml:lang="en">Objects considered to be within the numismatic domain such as coins, tokens, banknotes etc.</skos:definition>
+    </owl:Class>
+    
+
+
+    <!-- http://nomisma.org/ontology#NumismaticTerm -->
+
+    <owl:Class rdf:about="http://nomisma.org/ontology#NumismaticTerm">
+        <rdfs:comment xml:lang="en">A term used within the field of numismatics to describe or to otherwise convey information specific to the numismatic discipline, or to numismatic objects.</rdfs:comment>
+        <rdfs:label>NumismaticTerm</rdfs:label>
+        <skos:definition xml:lang="en">A term used within the field of numismatics to describe or to otherwise convey information specific to the numismatic discipline, or to numismatic objects.</skos:definition>
+    </owl:Class>
+    
+
+
+    <!-- http://nomisma.org/ontology#ObjectType -->
+
+    <owl:Class rdf:about="http://nomisma.org/ontology#ObjectType"/>
+    
+
+
+    <!-- http://nomisma.org/ontology#Peculiarity -->
+
+    <owl:Class rdf:about="http://nomisma.org/ontology#Peculiarity">
+        <rdfs:comment xml:lang="en">A notable, characteristic or unusual physical feature of an individual numismatic object that marks it out from other examples of the same group, or of a group of numismatic objects that marks it out from other groups.</rdfs:comment>
+        <rdfs:label>Peculiarity</rdfs:label>
+        <skos:definition xml:lang="en">A notable, characteristic or unusual physical feature of an individual numismatic object that marks it out from other examples of the same group, or of a group of numismatic objects that marks it out from other groups.</skos:definition>
+    </owl:Class>
+    
+
+
+    <!-- http://nomisma.org/ontology#PeculiarityOfProduction -->
+
+    <owl:Class rdf:about="http://nomisma.org/ontology#PeculiarityOfProduction">
+        <rdfs:subClassOf rdf:resource="http://nomisma.org/ontology#Peculiarity"/>
+        <rdfs:comment xml:lang="en">A notable, characteristic or unusual physical feature of an individual numismatic object which distinguishes it from other examples of the same group, or of a group of numismatic objects that marks it out from other groups, and which is related to the process of production of a numismatic object.</rdfs:comment>
+        <rdfs:label>PeculiarityOfProduction</rdfs:label>
+        <skos:definition xml:lang="en">A notable, characteristic or unusual physical feature of an individual numismatic object which distinguishes it from other examples of the same group, or of a group of numismatic objects that marks it out from other groups, and which is related to the process of production of a numismatic object.</skos:definition>
+    </owl:Class>
+    
+
+
+    <!-- http://nomisma.org/ontology#ReferenceWork -->
+
+    <owl:Class rdf:about="http://nomisma.org/ontology#ReferenceWork">
+        <rdfs:subClassOf rdf:resource="http://purl.org/dc/terms/BibliographicResource"/>
+    </owl:Class>
+    
+
+
+    <!-- http://nomisma.org/ontology#Region -->
+
+    <owl:Class rdf:about="http://nomisma.org/ontology#Region"/>
+    
+
+
+    <!-- http://nomisma.org/ontology#SecondaryTreatment -->
+
+    <owl:Class rdf:about="http://nomisma.org/ontology#SecondaryTreatment">
+        <rdfs:subClassOf rdf:resource="http://nomisma.org/ontology#Peculiarity"/>
+        <rdfs:comment xml:lang="en">Anomalies or unusual features which arise subsequent to the actual production of a numismatic object; for example halving, chop-marking, etc.</rdfs:comment>
+        <rdfs:label>SecondaryTreatment</rdfs:label>
+        <skos:definition xml:lang="en">Anomalies or unusual features which arise subsequent to the actual production of a numismatic object; for example halving, chop-marking, etc.</skos:definition>
+    </owl:Class>
+    
+
+
+    <!-- http://nomisma.org/ontology#Shape -->
+
+    <owl:Class rdf:about="http://nomisma.org/ontology#Shape">
+        <rdfs:comment xml:lang="en">The possible shapes numismatic objects might have, could be standard like round or rectangular or even a polygon.</rdfs:comment>
+        <rdfs:label>Shape</rdfs:label>
+        <skos:definition xml:lang="en">The possible shapes numismatic objects might have, could be standard like round or rectangular or even a polygon.</skos:definition>
+    </owl:Class>
+    
+
+
+    <!-- http://nomisma.org/ontology#StratigraphicUnit -->
+
+    <owl:Class rdf:about="http://nomisma.org/ontology#StratigraphicUnit">
+        <rdfs:comment xml:lang="en">A stratigraphic unit is a volume of identifiable origin and relative age range that is defined by the distinctive and dominant, easily mapped and recognizable features that characterize it.</rdfs:comment>
+        <rdfs:label xml:lang="en">StratigraphicUnit</rdfs:label>
+        <skos:definition xml:lang="en">A stratigraphic unit is a volume of identifiable origin and relative age range that is defined by the distinctive and dominant, easily mapped and recognizable features that characterize it.</skos:definition>
+    </owl:Class>
+    
+
+
+    <!-- http://nomisma.org/ontology#TypeSeries -->
+
+    <owl:Class rdf:about="http://nomisma.org/ontology#TypeSeries">
+        <rdfs:subClassOf rdf:resource="http://nomisma.org/ontology#ReferenceWork"/>
+    </owl:Class>
+    
+
+
+    <!-- http://nomisma.org/ontology#TypeSeriesItem -->
+
+    <owl:Class rdf:about="http://nomisma.org/ontology#TypeSeriesItem"/>
+    
+
+
+    <!-- http://nomisma.org/ontology#Wear -->
+
+    <owl:Class rdf:about="http://nomisma.org/ontology#Wear"/>
+    
+
+
+    <!-- http://nomisma.org/ontology#WeightStandard -->
+
+    <owl:Class rdf:about="http://nomisma.org/ontology#WeightStandard">
+        <rdfs:subClassOf rdf:resource="http://purl.org/dc/terms/Standard"/>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.org/dc/terms/BibliographicResource -->
+
+    <owl:Class rdf:about="http://purl.org/dc/terms/BibliographicResource"/>
+    
+
+
+    <!-- http://purl.org/dc/terms/Standard -->
+
+    <owl:Class rdf:about="http://purl.org/dc/terms/Standard"/>
+    
+
+
+    <!-- 
+    ///////////////////////////////////////////////////////////////////////////////////////
+    //
+    // Individuals
+    //
+    ///////////////////////////////////////////////////////////////////////////////////////
+     -->
+
+    
+
+
+    <!-- http://nomisma.org/id/coin -->
+
+    <owl:NamedIndividual rdf:about="http://nomisma.org/id/coin">
+        <owl:sameAs rdf:resource="http://nomisma.org/ontology#Coin"/>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://nomisma.org/ontology#Coin -->
+
+    <rdf:Description rdf:about="http://nomisma.org/ontology#Coin"/>
+    
+
+
+    <!-- http://nomisma.org/id/coin_wear -->
+
+    <owl:NamedIndividual rdf:about="http://nomisma.org/id/coin_wear">
+        <owl:sameAs rdf:resource="http://nomisma.org/ontology#CoinWear"/>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://nomisma.org/ontology#CoinWear -->
+
+    <rdf:Description rdf:about="http://nomisma.org/ontology#CoinWear"/>
+    
+
+
+    <!-- http://nomisma.org/id/collection -->
+
+    <owl:NamedIndividual rdf:about="http://nomisma.org/id/collection">
+        <owl:sameAs rdf:resource="http://nomisma.org/ontology#Collection"/>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://nomisma.org/ontology#Collection -->
+
+    <rdf:Description rdf:about="http://nomisma.org/ontology#Collection"/>
+    
+
+
+    <!-- http://nomisma.org/id/denomination -->
+
+    <owl:NamedIndividual rdf:about="http://nomisma.org/id/denomination">
+        <owl:sameAs rdf:resource="http://nomisma.org/ontology#Denomination"/>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://nomisma.org/ontology#Denomination -->
+
+    <rdf:Description rdf:about="http://nomisma.org/ontology#Denomination"/>
+    
+
+
+    <!-- http://nomisma.org/id/ethnic -->
+
+    <owl:NamedIndividual rdf:about="http://nomisma.org/id/ethnic">
+        <owl:sameAs rdf:resource="http://nomisma.org/ontology#Ethnic"/>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://nomisma.org/ontology#Ethnic -->
+
+    <rdf:Description rdf:about="http://nomisma.org/ontology#Ethnic"/>
+    
+
+
+    <!-- http://nomisma.org/id/field_of_numismatics -->
+
+    <owl:NamedIndividual rdf:about="http://nomisma.org/id/field_of_numismatics">
+        <owl:sameAs rdf:resource="http://nomisma.org/ontology#FieldOfNumismatics"/>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://nomisma.org/ontology#FieldOfNumismatics -->
+
+    <rdf:Description rdf:about="http://nomisma.org/ontology#FieldOfNumismatics"/>
+    
+
+
+    <!-- http://nomisma.org/id/manufacture -->
+
+    <owl:NamedIndividual rdf:about="http://nomisma.org/id/manufacture">
+        <owl:sameAs rdf:resource="http://nomisma.org/ontology#Manufacture"/>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://nomisma.org/ontology#Manufacture -->
+
+    <rdf:Description rdf:about="http://nomisma.org/ontology#Manufacture"/>
+    
+
+
+    <!-- http://nomisma.org/id/material -->
+
+    <owl:NamedIndividual rdf:about="http://nomisma.org/id/material">
+        <owl:sameAs rdf:resource="http://nomisma.org/ontology#Material"/>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://nomisma.org/ontology#Material -->
+
+    <rdf:Description rdf:about="http://nomisma.org/ontology#Material"/>
+    
+
+
+    <!-- http://nomisma.org/id/medal -->
+
+    <owl:NamedIndividual rdf:about="http://nomisma.org/id/medal">
+        <owl:sameAs rdf:resource="http://nomisma.org/ontology#Medal"/>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://nomisma.org/ontology#Medal -->
+
+    <rdf:Description rdf:about="http://nomisma.org/ontology#Medal"/>
+    
+
+
+    <!-- http://nomisma.org/id/mint -->
+
+    <owl:NamedIndividual rdf:about="http://nomisma.org/id/mint">
+        <owl:sameAs rdf:resource="http://nomisma.org/ontology#Mint"/>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://nomisma.org/ontology#Mint -->
+
+    <rdf:Description rdf:about="http://nomisma.org/ontology#Mint"/>
+    
+
+
+    <!-- http://nomisma.org/id/object_type -->
+
+    <owl:NamedIndividual rdf:about="http://nomisma.org/id/object_type">
+        <owl:sameAs rdf:resource="http://nomisma.org/ontology#ObjectType"/>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://nomisma.org/ontology#ObjectType -->
+
+    <rdf:Description rdf:about="http://nomisma.org/ontology#ObjectType"/>
+    
+
+
+    <!-- http://nomisma.org/id/reference_work -->
+
+    <owl:NamedIndividual rdf:about="http://nomisma.org/id/reference_work">
+        <owl:sameAs rdf:resource="http://nomisma.org/ontology#ReferenceWork"/>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://nomisma.org/ontology#ReferenceWork -->
+
+    <rdf:Description rdf:about="http://nomisma.org/ontology#ReferenceWork"/>
+    
+
+
+    <!-- http://nomisma.org/id/region -->
+
+    <owl:NamedIndividual rdf:about="http://nomisma.org/id/region">
+        <owl:sameAs rdf:resource="http://nomisma.org/ontology#Region"/>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://nomisma.org/ontology#Region -->
+
+    <rdf:Description rdf:about="http://nomisma.org/ontology#Region"/>
+    
+
+
+    <!-- http://nomisma.org/id/seal -->
+
+    <owl:NamedIndividual rdf:about="http://nomisma.org/id/seal">
+        <owl:sameAs rdf:resource="http://nomisma.org/ontology#Seal"/>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://nomisma.org/ontology#Seal -->
+
+    <rdf:Description rdf:about="http://nomisma.org/ontology#Seal"/>
+    
+
+
+    <!-- http://nomisma.org/id/type_series -->
+
+    <owl:NamedIndividual rdf:about="http://nomisma.org/id/type_series">
+        <owl:sameAs rdf:resource="http://nomisma.org/ontology#TypeSeries"/>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://nomisma.org/ontology#TypeSeries -->
+
+    <rdf:Description rdf:about="http://nomisma.org/ontology#TypeSeries"/>
+    
+
+
+    <!-- http://nomisma.org/id/type_series_item -->
+
+    <owl:NamedIndividual rdf:about="http://nomisma.org/id/type_series_item">
+        <owl:sameAs rdf:resource="http://nomisma.org/ontology#TypeSeriesItem"/>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://nomisma.org/ontology#TypeSeriesItem -->
+
+    <rdf:Description rdf:about="http://nomisma.org/ontology#TypeSeriesItem"/>
+    
+
+
+    <!-- http://nomisma.org/id/weight_standard -->
+
+    <owl:NamedIndividual rdf:about="http://nomisma.org/id/weight_standard">
+        <owl:sameAs rdf:resource="http://nomisma.org/ontology#WeightStandard"/>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://nomisma.org/ontology#WeightStandard -->
+
+    <rdf:Description rdf:about="http://nomisma.org/ontology#WeightStandard"/>
+    
+
+
+    <!-- http://nomisma.org/ontology#Coin -->
+
+    <owl:NamedIndividual rdf:about="http://nomisma.org/ontology#Coin"/>
+    
+
+
+    <!-- http://nomisma.org/ontology#CoinWear -->
+
+    <owl:NamedIndividual rdf:about="http://nomisma.org/ontology#CoinWear"/>
+    
+
+
+    <!-- http://nomisma.org/ontology#Collection -->
+
+    <owl:NamedIndividual rdf:about="http://nomisma.org/ontology#Collection"/>
+    
+
+
+    <!-- http://nomisma.org/ontology#Denomination -->
+
+    <owl:NamedIndividual rdf:about="http://nomisma.org/ontology#Denomination"/>
+    
+
+
+    <!-- http://nomisma.org/ontology#Ethnic -->
+
+    <owl:NamedIndividual rdf:about="http://nomisma.org/ontology#Ethnic"/>
+    
+
+
+    <!-- http://nomisma.org/ontology#FieldOfNumismatics -->
+
+    <owl:NamedIndividual rdf:about="http://nomisma.org/ontology#FieldOfNumismatics"/>
+    
+
+
+    <!-- http://nomisma.org/ontology#Manufacture -->
+
+    <owl:NamedIndividual rdf:about="http://nomisma.org/ontology#Manufacture"/>
+    
+
+
+    <!-- http://nomisma.org/ontology#Material -->
+
+    <owl:NamedIndividual rdf:about="http://nomisma.org/ontology#Material"/>
+    
+
+
+    <!-- http://nomisma.org/ontology#Medal -->
+
+    <owl:NamedIndividual rdf:about="http://nomisma.org/ontology#Medal"/>
+    
+
+
+    <!-- http://nomisma.org/ontology#Medallion -->
+
+    <owl:NamedIndividual rdf:about="http://nomisma.org/ontology#Medallion"/>
+    
+
+
+    <!-- http://nomisma.org/ontology#Mint -->
+
+    <owl:NamedIndividual rdf:about="http://nomisma.org/ontology#Mint"/>
+    
+
+
+    <!-- http://nomisma.org/ontology#ObjectType -->
+
+    <owl:NamedIndividual rdf:about="http://nomisma.org/ontology#ObjectType"/>
+    
+
+
+    <!-- http://nomisma.org/ontology#ReferenceWork -->
+
+    <owl:NamedIndividual rdf:about="http://nomisma.org/ontology#ReferenceWork"/>
+    
+
+
+    <!-- http://nomisma.org/ontology#Region -->
+
+    <owl:NamedIndividual rdf:about="http://nomisma.org/ontology#Region"/>
+    
+
+
+    <!-- http://nomisma.org/ontology#Seal -->
+
+    <owl:NamedIndividual rdf:about="http://nomisma.org/ontology#Seal"/>
+    
+
+
+    <!-- http://nomisma.org/ontology#Tessera -->
+
+    <owl:NamedIndividual rdf:about="http://nomisma.org/ontology#Tessera"/>
+    
+
+
+    <!-- http://nomisma.org/ontology#Token -->
+
+    <owl:NamedIndividual rdf:about="http://nomisma.org/ontology#Token"/>
+    
+
+
+    <!-- http://nomisma.org/ontology#TypeSeries -->
+
+    <owl:NamedIndividual rdf:about="http://nomisma.org/ontology#TypeSeries"/>
+    
+
+
+    <!-- http://nomisma.org/ontology#TypeSeriesItem -->
+
+    <owl:NamedIndividual rdf:about="http://nomisma.org/ontology#TypeSeriesItem"/>
+    
+
+
+    <!-- http://nomisma.org/ontology#Wear -->
+
+    <owl:NamedIndividual rdf:about="http://nomisma.org/ontology#Wear"/>
+    
+
+
+    <!-- http://nomisma.org/ontology#WeightStandard -->
+
+    <owl:NamedIndividual rdf:about="http://nomisma.org/ontology#WeightStandard"/>
+    
+
+
+    <!-- 
+    ///////////////////////////////////////////////////////////////////////////////////////
+    //
+    // Annotations
+    //
+    ///////////////////////////////////////////////////////////////////////////////////////
+     -->
+
+    <rdf:Description rdf:about="http://nomisma.org/ontology#CoinWear">
+        <rdfs:comment xml:lang="en">Wear on a coin or similar objects occurring as a result of its use.</rdfs:comment>
+        <rdfs:label>CoinWear</rdfs:label>
+        <skos:definition xml:lang="en">Wear on a coin or similar objects occurring as a result of its use.</skos:definition>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://nomisma.org/ontology#Collection">
+        <rdfs:comment xml:lang="en">General term meaning the objects held by an institution or individual. Or the holding entity itself.</rdfs:comment>
+        <rdfs:label>Collection</rdfs:label>
+        <skos:definition xml:lang="en">General term meaning the objects held by an institution or individual. Or the holding entity itself.</skos:definition>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://nomisma.org/ontology#Denomination">
+        <rdfs:comment xml:lang="en">Term indicating the value of a numismatic object. Examples: tetradrachm, chalkous, denarius.</rdfs:comment>
+        <rdfs:label>Denomination</rdfs:label>
+        <skos:definition xml:lang="en">Term indicating the value of a numismatic object. Examples: tetradrachm, chalkous, denarius.</skos:definition>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://nomisma.org/ontology#Ethnic">
+        <rdfs:comment xml:lang="en">Generally, a tribal or ethnic name appearing on a numismatic object. Distinct from personal authority as indicated by the presence of ruler&apos;s name.</rdfs:comment>
+        <rdfs:label>Ethnic</rdfs:label>
+        <skos:definition xml:lang="en">Generally, a tribal or ethnic name appearing on a numismatic object. Distinct from personal authority as indicated by the presence of ruler&apos;s name.</skos:definition>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://nomisma.org/ontology#FieldOfNumismatics">
+        <rdfs:comment xml:lang="en">Any widely recognized area of study within the discipline of numismatics.</rdfs:comment>
+        <rdfs:label>FieldOfNumismatics</rdfs:label>
+        <skos:definition xml:lang="en">Any widely recognized area of study within the discipline of numismatics.</skos:definition>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://nomisma.org/ontology#Manufacture">
+        <rdfs:comment xml:lang="en">The technique of manufacture. For example, struck or cast.</rdfs:comment>
+        <rdfs:label>Manufacture</rdfs:label>
+        <skos:definition xml:lang="en">The technique of manufacture. For example, struck or cast.</skos:definition>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://nomisma.org/ontology#Material">
+        <rdfs:comment xml:lang="en">The physical material from which an object is made.</rdfs:comment>
+        <rdfs:label>Material</rdfs:label>
+        <skos:definition xml:lang="en">The physical material from which an object is made.</skos:definition>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://nomisma.org/ontology#Mint">
+        <rdfs:comment xml:lang="en">Generic term for a place of manufacture of a numismatic object or for the issuing city.</rdfs:comment>
+        <rdfs:label>Mint</rdfs:label>
+        <skos:definition xml:lang="en">Generic term for a place of manufacture of a numismatic object or for the issuing city.</skos:definition>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://nomisma.org/ontology#ObjectType">
+        <rdfs:comment xml:lang="en">The numismatic type of an object. Ex. &apos;coin&apos;.</rdfs:comment>
+        <rdfs:label>ObjectType</rdfs:label>
+        <skos:definition xml:lang="en">The numismatic type of an object. Ex. &apos;coin&apos;.</skos:definition>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://nomisma.org/ontology#ReferenceWork">
+        <rdfs:comment xml:lang="en">A published work of reference relevant to a numismatic object.</rdfs:comment>
+        <rdfs:label>ReferenceWork</rdfs:label>
+        <skos:definition xml:lang="en">A published work of reference relevant to a numismatic object.</skos:definition>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://nomisma.org/ontology#Region">
+        <rdfs:comment xml:lang="en">An area of geographic significance and/or taxonomic importance, perhaps part of a larger geographic/administrative unit, having definable characteristics but not always fixed boundaries.</rdfs:comment>
+        <rdfs:label>Region</rdfs:label>
+        <skos:definition xml:lang="en">An area of geographic significance and/or taxonomic importance, perhaps part of a larger geographic/administrative unit, having definable characteristics but not always fixed boundaries.</skos:definition>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://nomisma.org/ontology#TypeSeries">
+        <rdfs:comment xml:lang="en">A published or recognized reference list of numismatic object types, such as a catalogue or corpus.</rdfs:comment>
+        <rdfs:label>TypeSeries</rdfs:label>
+        <skos:definition xml:lang="en">A published or recognized reference list of numismatic object types, such as a catalogue or corpus.</skos:definition>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://nomisma.org/ontology#TypeSeriesItem">
+        <rdfs:comment xml:lang="en">An item within a reference list of numismatic object types.</rdfs:comment>
+        <rdfs:label>TypeSeriesItem</rdfs:label>
+        <skos:definition xml:lang="en">An item within a reference list of numismatic object types.</skos:definition>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://nomisma.org/ontology#Wear">
+        <rdfs:comment xml:lang="en">Wear on a numismatic object occurring as a result of its use.</rdfs:comment>
+        <rdfs:label>Wear</rdfs:label>
+        <skos:definition xml:lang="en">Wear on a numismatic object occurring as a result of its use.</skos:definition>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://nomisma.org/ontology#WeightStandard">
+        <rdfs:comment xml:lang="en">The conventional weight system according to which a numismatic object was produced.</rdfs:comment>
+        <rdfs:label>WeightStandard</rdfs:label>
+        <skos:definition xml:lang="en">The conventional weight system according to which a numismatic object was produced.</skos:definition>
+    </rdf:Description>
+</rdf:RDF>
+
+
+
+<!-- Generated by the OWL API (version 4.5.29.2024-05-13T12:11:03Z) https://github.com/owlcs/owlapi -->
+

--- a/ontology/ontology.250402.ttl
+++ b/ontology/ontology.250402.ttl
@@ -1,0 +1,1108 @@
+@prefix : <http://nomisma.org/ontology#> .
+@prefix crm: <http://www.cidoc-crm.org/cidoc-crm/> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix xml: <http://www.w3.org/XML/1998/namespace> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+@prefix dcterms: <http://purl.org/dc/terms/> .
+@prefix dcmitype: <http://purl.org/dc/dcmitype/> .
+@base <http://nomisma.org/ontology#> .
+
+<http://nomisma.org/ontology#> rdf:type owl:Ontology ;
+                                dcterms:date "2025-01-22" ;
+                                rdfs:comment "Nomisma.org is a collaborative project to provide stable digital representations of numismatic concepts according to the principles of Linked Open Data. These take the form of http URIs that also provide access to reusable information about those concepts, along with links to other resources."@en ;
+                                owl:versionInfo """Version of 2025-04-02:
+changes:
+changed from owl:ObjectProperty to rdf:Property
+nmo:hasFindsport as supPropertyOf (sPO) nmo:hasFindContext
+nmo:hasEndDate and nmo:hasStartDate as sPO nmo:hasDate
+nmo:hasStatedAuthority as sPO nmo:Appearance
+nmo:isAbove, nmo:isBelow, nmo:isEqual as sPO of nmo:hasContext
+nmo:hasControlmark as sPO nmo:hasMark
+new:
+nmo:hasMeasurement as SuperProperty for: nmo:hasDiameter, nmo:hasDepth, nmo:hasWidth, nmo:hasHeight, nmo:hasWeight (just for a better structuring)"""@en ;
+                                skos:definition "Nomisma.org is a collaborative project to provide stable digital representations of numismatic concepts according to the principles of Linked Open Data. These take the form of http URIs that also provide access to reusable information about those concepts, along with links to other resources."@en .
+
+#################################################################
+#    Annotation properties
+#################################################################
+
+###  http://purl.org/dc/terms/date
+dcterms:date rdf:type owl:AnnotationProperty .
+
+
+###  http://www.w3.org/2004/02/skos/core#definition
+skos:definition rdf:type owl:AnnotationProperty .
+
+
+#################################################################
+#    Properties
+#################################################################
+
+###  http://nomisma.org/ontology#hasAppearance
+:hasAppearance rdf:type rdf:Property ;
+               rdfs:comment "Describes the appearance of a numismatic object. Eg. Iconography, legends and physical characteristics."@en ;
+               rdfs:label "hasAppearance" ;
+               skos:definition "Describes the appearance of a numismatic object. Eg. Iconography, legends and physical characteristics."@en .
+
+
+###  http://nomisma.org/ontology#hasAuthenticity
+:hasAuthenticity rdf:type rdf:Property ;
+                 rdfs:comment "Identifies whether a numismatic object was produced by an authority that had the relevant rights to do so, or is a contemporary or modern imitation."@en ;
+                 rdfs:label "hasAuthenticity" ;
+                 skos:definition "Identifies whether a numismatic object was produced by an authority that had the relevant rights to do so, or is a contemporary or modern imitation."@en .
+
+
+###  http://nomisma.org/ontology#hasAuthority
+:hasAuthority rdf:type rdf:Property ;
+              rdfs:comment "Identifies the authority in whose name (explicitly or implicitly) a numismatic object was issued. Eg. Charlemagne, Augustus, Sparta, Federal Republic of Germany, Bank of England"@en ;
+              rdfs:label "hasAuthority" ;
+              skos:definition "Identifies the authority in whose name (explicitly or implicitly) a numismatic object was issued. Eg. Charlemagne, Augustus, Sparta, Federal Republic of Germany, Bank of England"@en .
+
+
+###  http://nomisma.org/ontology#hasAxis
+:hasAxis rdf:type rdf:Property ;
+         rdfs:subPropertyOf :hasAppearance ;
+         rdfs:comment "Describes the directional relationship between the obverse and reverse of a numismatic object."@en ;
+         rdfs:label "hasAxis" ;
+         skos:definition "Describes the directional relationship between the obverse and reverse of a numismatic object."@en .
+
+
+###  http://nomisma.org/ontology#hasBearsDate
+:hasBearsDate rdf:type rdf:Property ;
+              rdfs:subPropertyOf :hasAppearance ;
+              rdfs:comment "Describes a date that appears on an object"@en ;
+              rdfs:label "hasBearsDate" ;
+              skos:definition "Describes a date that appears on an object"@en .
+
+
+###  http://nomisma.org/ontology#hasClosingDate
+:hasClosingDate rdf:type rdf:Property ;
+                rdfs:subPropertyOf :hasDate ;
+                rdfs:comment "The date of the latest object (could be non-numismatic) of a given context, e.g. a hoard or layer."@en ;
+                rdfs:label "hasClosingDate" ;
+                skos:definition "The date of the latest object (could be non-numismatic) of a given context, e.g. a hoard or layer."@en .
+
+
+###  http://nomisma.org/ontology#hasCollection
+:hasCollection rdf:type rdf:Property ;
+               rdfs:comment "Identifies the modern collection or repository in which a numismatic object resides or has resided in the past."@en ;
+               rdfs:label "hasCollection" ;
+               skos:definition "Identifies the modern collection or repository in which a numismatic object resides or has resided in the past."@en .
+
+
+###  http://nomisma.org/ontology#hasContemporaryName
+:hasContemporaryName rdf:type rdf:Property ;
+                     rdfs:subPropertyOf dcterms:alternative ;
+                     rdfs:comment "A contemporary name is a term for a particular group of numismatic objects or concept(s)  that was used for them at the time of their use. This may, for example, include one or more denominations, numismatic objects of a particular origin or some other common characteristic. Examples: Poloi, Tournois, Spagürli, Etschkreuzer, F-Schilling, Popolino."@en ;
+                     rdfs:label "hasContemporaryName" ;
+                     skos:definition "A contemporary name is a term for a particular group of numismatic objects or concept(s)  that was used for them at the time of their use. This may, for example, include one or more denominations, numismatic objects of a particular origin or some other common characteristic. Examples: Poloi, Tournois, Spagürli, Etschkreuzer, F-Schilling, Popolino."@en .
+
+
+###  http://nomisma.org/ontology#hasContext
+:hasContext rdf:type rdf:Property ;
+            rdfs:comment "Describes the context of a numismatic object."@en ;
+            rdfs:label "hasContext" ;
+            skos:definition "Describes the context of a numismatic object."@en .
+
+
+###  http://nomisma.org/ontology#hasControlmark
+:hasControlmark rdf:type rdf:Property ;
+                rdfs:subPropertyOf :hasMark ;
+                rdfs:comment "Identifies a letter, symbol, monogram or an inscription on a numismatic object intended to distinguish it as part of a group of numismatic objects within an issue or series."@en ;
+                rdfs:label "hasControlmark" ;
+                skos:definition "Identifies a letter, symbol, monogram or an inscription on a numismatic object intended to distinguish it as part of a group of numismatic objects within an issue or series."@en .
+
+
+###  http://nomisma.org/ontology#hasCorrosion
+:hasCorrosion rdf:type rdf:Property ;
+              rdfs:comment "Describes degradation due to chemical reaction with an environment, commonly in terms prescribed by \"Abnutzung und Korrosion: Bestimmmungstafeln zur Bearbeitung von Fundmünzen = Usure et corrosion. (1995). Lausanne.\" (OCLC 174260520)"@en ;
+              rdfs:label "hasCorrosion" ;
+              skos:definition "Describes degradation due to chemical reaction with an environment, commonly in terms prescribed by \"Abnutzung und Korrosion: Bestimmmungstafeln zur Bearbeitung von Fundmünzen = Usure et corrosion. (1995). Lausanne.\" (OCLC 174260520)"@en .
+
+
+###  http://nomisma.org/ontology#hasCountermark
+:hasCountermark rdf:type rdf:Property ;
+                rdfs:subPropertyOf :hasIconography ,
+                                   :hasSecondaryTreatment ;
+                rdfs:comment "Identifies a mark or symbol punched into a coin or similar object  at some point during its time in circulation."@en ;
+                rdfs:label "hasCountermark" ;
+                skos:definition "Identifies a mark or symbol punched into a coin or similar object  at some point during its time in circulation."@en .
+
+
+###  http://nomisma.org/ontology#hasDate
+:hasDate rdf:type rdf:Property ;
+         rdfs:comment "Describes date (range) assigned in a numismatic context."@en ;
+         rdfs:label "hasDate" ;
+         skos:definition "Describes date (range) assigned in a numismatic context."@en .
+
+
+###  http://nomisma.org/ontology#hasDenomination
+:hasDenomination rdf:type rdf:Property ;
+                 rdfs:comment "Describes the monetary value assigned to an object within a denominational system. Examples: tetradrachm, chalkous, denarius."@en ;
+                 rdfs:label "hasDenomination" ;
+                 skos:definition "Describes the monetary value assigned to an object within a denominational system. Examples: tetradrachm, chalkous, denarius."@en .
+
+
+###  http://nomisma.org/ontology#hasDepth
+:hasDepth rdf:type rdf:Property ;
+          rdfs:subPropertyOf :hasMeasurement ;
+          rdfs:comment "Describes the depth of an object."@en ;
+          rdfs:label "hasDepth" ;
+          skos:definition "Describes the depth of an object."@en .
+
+
+###  http://nomisma.org/ontology#hasDiameter
+:hasDiameter rdf:type rdf:Property ;
+             rdfs:subPropertyOf :hasMeasurement ;
+             rdfs:comment "Describes diameter of an object."@en ;
+             rdfs:label "hasDiameter" ;
+             skos:definition "Describes diameter of an object."@en .
+
+
+###  http://nomisma.org/ontology#hasDie
+:hasDie rdf:type rdf:Property ;
+        rdfs:subPropertyOf :hasProductionObject ;
+        rdfs:comment "Describes the die from which a numismatic object has been produced."@en ;
+        rdfs:label "hasDie" ;
+        skos:definition "Describes the die from which a numismatic object has been produced."@en .
+
+
+###  http://nomisma.org/ontology#hasEdge
+:hasEdge rdf:type rdf:Property ;
+         rdfs:subPropertyOf :hasAppearance ;
+         rdfs:comment "Describes characteristics of the edge of a numismatic object."@en ;
+         rdfs:label "hasEdge" ;
+         skos:definition "Describes characteristics of the edge of a numismatic object."@en .
+
+
+###  http://nomisma.org/ontology#hasEndDate
+:hasEndDate rdf:type rdf:Property ;
+            rdfs:subPropertyOf :hasDate ;
+            rdfs:comment "Identifies the final date in a range assigned in a numismatic context."@en ;
+            rdfs:label "hasEndDate" ;
+            skos:definition "Identifies the final date in a range assigned in a numismatic context."@en .
+
+
+###  http://nomisma.org/ontology#hasFace
+:hasFace rdf:type rdf:Property ;
+         rdfs:subPropertyOf :hasAppearance ;
+         rdfs:comment "Identifies a particular face of a numismatic object. Where possible and appropriate, the more specific properties hasObverse or hasReverse are preferred."@en ;
+         rdfs:label "hasFace" ;
+         skos:definition "Identifies a particular face of a numismatic object. Where possible and appropriate, the more specific properties hasObverse or hasReverse are preferred."@en .
+
+
+###  http://nomisma.org/ontology#hasFindContext
+:hasFindContext rdf:type rdf:Property ;
+                rdfs:subPropertyOf :hasContext ;
+                rdfs:comment "Describes the context regarding the discovery/find of a numismatic object."@en ;
+                rdfs:label "hasFindContext" ;
+                skos:definition "Describes the context regarding the discovery/find of a numismatic object."@en .
+
+
+###  http://nomisma.org/ontology#hasFindType
+:hasFindType rdf:type rdf:Property ;
+             rdfs:label "hasFindType" ;
+             owl:deprecated "deprecated - please use nmo:hasContext instead, together with the class Context or its sub classes: Find, DepositionType and DiscoveryType" ;
+             skos:definition "Describes the nature of and archaeological or other find. E.g. hoard, ritual deposit, single find, find in survey."@en .
+
+
+###  http://nomisma.org/ontology#hasFindspot
+:hasFindspot rdf:type rdf:Property ;
+             rdfs:subPropertyOf :hasFindContext ;
+             rdfs:comment "Describes the location of the discovery of an object, whether by accident or in archaeological excavation."@en ;
+             rdfs:label "hasFindspot" ;
+             skos:definition "Describes the location of the discovery of an object, whether by accident or in archaeological excavation."@en .
+
+
+###  http://nomisma.org/ontology#hasHeight
+:hasHeight rdf:type rdf:Property ;
+           rdfs:subPropertyOf :hasMeasurement ;
+           rdfs:comment "Describes the height of a numismatic object."@en ;
+           rdfs:label "hasHeight" ;
+           skos:definition "Describes the height of a numismatic object."@en .
+
+
+###  http://nomisma.org/ontology#hasIconography
+:hasIconography rdf:type rdf:Property ;
+                rdfs:subPropertyOf :hasAppearance ;
+                rdfs:comment "Describes an iconography placed on a numismatic object."@en ;
+                rdfs:label "hasIconography" ;
+                skos:definition "Describes an iconography placed on a numismatic object."@en .
+
+
+###  http://nomisma.org/ontology#hasImmediateContext
+:hasImmediateContext rdf:type rdf:Property ;
+                     rdfs:subPropertyOf :hasFindContext ;
+                     rdfs:comment "Is the precise context of the findspot such as under the hearth, in the wall, under the floor, in a ditch, on a river bed, etc."@en ;
+                     rdfs:label "hasImmediateContext" ;
+                     skos:definition "Is the precise context of the findspot such as under the hearth, in the wall, under the floor, in a ditch, on a river bed, etc."@en .
+
+
+###  http://nomisma.org/ontology#hasIssuer
+:hasIssuer rdf:type rdf:Property ;
+           rdfs:comment "Identifies the person administratively responsible for the issue of a numismatic object, generally named in some capacity on the object."@en ;
+           rdfs:label "hasIssuer" ;
+           skos:definition "Identifies the person administratively responsible for the issue of a numismatic object, generally named in some capacity on the object."@en .
+
+
+###  http://nomisma.org/ontology#hasLandscapeContext
+:hasLandscapeContext rdf:type rdf:Property ;
+                     rdfs:subPropertyOf :hasFindContext ;
+                     rdfs:comment "Is the broad scale findspot landscape type such as: urban, rural, underwater (as instances of nmo:Context in the ID namespace)."@en ;
+                     rdfs:label "hasLandscapeContext" ;
+                     skos:definition "Is the broad scale findspot landscape type such as: urban, rural, underwater (as instances of nmo:Context in the ID namespace)."@en .
+
+
+###  http://nomisma.org/ontology#hasLegend
+:hasLegend rdf:type rdf:Property ;
+           rdfs:subPropertyOf :hasAppearance ;
+           rdfs:comment "Describes the inscription or printing placed on a numismatic object as part of the production process."@en ;
+           rdfs:label "hasLegend" ;
+           skos:definition "Describes the inscription or printing placed on a numismatic object as part of the production process."@en .
+
+
+###  http://nomisma.org/ontology#hasLocalContext
+:hasLocalContext rdf:type rdf:Property ;
+                 rdfs:subPropertyOf :hasFindContext ;
+                 rdfs:comment "Is the findspot in relation to nearby features such as: from a field, in a temple, in an otherwise unspecified structure, in a shipwreck."@en ;
+                 rdfs:label "hasLocalContext" ;
+                 skos:definition "Is the findspot in relation to nearby features such as: from a field, in a temple, in an otherwise unspecified structure, in a shipwreck."@en .
+
+
+###  http://nomisma.org/ontology#hasManufacture
+:hasManufacture rdf:type rdf:Property ;
+                rdfs:comment "Describes the method of manufacture of a numismatic object. Eg. struck, cast, printed"@en ;
+                rdfs:label "hasManufacture" ;
+                skos:definition "Describes the method of manufacture of a numismatic object. Eg. struck, cast, printed"@en .
+
+
+###  http://nomisma.org/ontology#hasMark
+:hasMark rdf:type rdf:Property ;
+         rdfs:subPropertyOf :hasAppearance ;
+         rdfs:comment "Any kind of mark, e.g. a character, letter, symbol or an inscription on a numismatic object. No intension for the mark is predefined by this property. It could be a mark generated during production or as a secondary treatment."@en ;
+         rdfs:label "hasMark" ;
+         skos:definition "Any kind of mark, e.g. a character, letter, symbol or an inscription on a numismatic object. No intension for the mark is predefined by this property. It could be a mark generated during production or as a secondary treatment."@en .
+
+
+###  http://nomisma.org/ontology#hasMaterial
+:hasMaterial rdf:type rdf:Property ;
+             rdfs:subPropertyOf owl:topObjectProperty ;
+             rdfs:comment "Describes the physical material from which a numismatic object is made."@en ;
+             rdfs:label "hasMaterial" ;
+             skos:definition "Describes the physical material from which a numismatic object is made."@en .
+
+
+###  http://nomisma.org/ontology#hasMaxDepth
+:hasMaxDepth rdf:type rdf:Property ;
+             rdfs:subPropertyOf :hasDepth ;
+             rdfs:comment "Describes the maximum depth of a numismatic object."@en ;
+             rdfs:label "hasMaxDepth" ;
+             skos:definition "Describes the maximum depth of a numismatic object."@en .
+
+
+###  http://nomisma.org/ontology#hasMaxDiameter
+:hasMaxDiameter rdf:type rdf:Property ;
+                rdfs:subPropertyOf :hasDiameter ;
+                rdfs:comment "Describes the maximum diameter of a numismatic object."@en ;
+                rdfs:label "hasMaxDiameter" ;
+                skos:definition "Describes the maximum diameter of a numismatic object."@en .
+
+
+###  http://nomisma.org/ontology#hasMaxHeight
+:hasMaxHeight rdf:type rdf:Property ;
+              rdfs:subPropertyOf :hasHeight ;
+              rdfs:comment "Describes the maximum height of a numismatic object."@en ;
+              rdfs:label "hasMaxHeight" ;
+              skos:definition "Describes the maximum height of a numismatic object."@en .
+
+
+###  http://nomisma.org/ontology#hasMaxWidth
+:hasMaxWidth rdf:type rdf:Property ;
+             rdfs:subPropertyOf :hasWidth ;
+             rdfs:comment "Describes the maximum width of a numismatic object."@en ;
+             rdfs:label "hasMaxWidth" ;
+             skos:definition "Describes the maximum width of a numismatic object."@en .
+
+
+###  http://nomisma.org/ontology#hasMeasurement
+:hasMeasurement rdf:type rdf:Property ;
+                rdfs:comment "Introduced for better structuring of subproperties like nmo:hasWidth, nmo:hasHeight ... not intended to be used directly. (abstract)"@en ;
+                rdfs:label "hasMeasurement" ;
+                skos:definition "Introduced for better structuring of subproperties like nmo:hasWidth, nmo:hasHeight ... not intended to be used directly. (abstract)"@en .
+
+
+###  http://nomisma.org/ontology#hasMinDepth
+:hasMinDepth rdf:type rdf:Property ;
+             rdfs:subPropertyOf :hasDepth ;
+             rdfs:comment "Describes the minimum depth of a numismatic object."@en ;
+             rdfs:label "hasMinDepth" ;
+             skos:definition "Describes the minimum depth of a numismatic object."@en .
+
+
+###  http://nomisma.org/ontology#hasMinDiameter
+:hasMinDiameter rdf:type rdf:Property ;
+                rdfs:subPropertyOf :hasDiameter ;
+                rdfs:comment "Describes the minimum diameter of a numismatic object."@en ;
+                rdfs:label "hasMinDiameter" ;
+                skos:definition "Describes the minimum diameter of a numismatic object."@en .
+
+
+###  http://nomisma.org/ontology#hasMinHeight
+:hasMinHeight rdf:type rdf:Property ;
+              rdfs:subPropertyOf :hasHeight ;
+              rdfs:comment "Describes the minimum height of a numismatic object."@en ;
+              rdfs:label "hasMinHeight" ;
+              skos:definition "Describes the minimum height of a numismatic object."@en .
+
+
+###  http://nomisma.org/ontology#hasMinWidth
+:hasMinWidth rdf:type rdf:Property ;
+             rdfs:subPropertyOf :hasWidth ;
+             rdfs:comment "Describes the minimum width of a numismatic object."@en ;
+             rdfs:label "hasMinWidth" ;
+             skos:definition "Describes the minimum width of a numismatic object."@en .
+
+
+###  http://nomisma.org/ontology#hasMint
+:hasMint rdf:type rdf:Property ;
+         rdfs:comment "Identifies the place of manufacture or issue of a numismatic object."@en ;
+         rdfs:label "hasMint" ;
+         skos:definition "Identifies the place of manufacture or issue of a numismatic object."@en .
+
+
+###  http://nomisma.org/ontology#hasMintmark
+:hasMintmark rdf:type rdf:Property ;
+             rdfs:subPropertyOf :hasControlmark ;
+             rdfs:comment "Identifies the letter, symbol or an inscription on a numismatic object indicating the mint where it was produced."@en ;
+             rdfs:label "hasMintmark" ;
+             skos:definition "Identifies the letter, symbol or an inscription on a numismatic object indicating the mint where it was produced."@en .
+
+
+###  http://nomisma.org/ontology#hasNumismaticClosingDate
+:hasNumismaticClosingDate rdf:type rdf:Property ;
+                          rdfs:subPropertyOf :hasDate ;
+                          rdfs:comment "The date of the latest numismatic object of a given context, e.g. a hoard or layer."@en ;
+                          rdfs:label "hasNumismaticClosingDate" ;
+                          skos:definition "The date of the latest numismatic object of a given context, e.g. a hoard or layer."@en .
+
+
+###  http://nomisma.org/ontology#hasNumismaticOpeningDate
+:hasNumismaticOpeningDate rdf:type rdf:Property ;
+                          rdfs:subPropertyOf :hasDate ;
+                          rdfs:comment "The date of the earliest numismatic object of a given context, e.g. a hoard or layer."@en ;
+                          rdfs:label "hasNumismaticOpeningDate" ;
+                          skos:definition "The date of the earliest numismatic object of a given context, e.g. a hoard or layer."@en .
+
+
+###  http://nomisma.org/ontology#hasObjectType
+:hasObjectType rdf:type rdf:Property ;
+               rdfs:comment "Identifies the type of numismatic object. E.g. Coin, token, banknote."@en ;
+               rdfs:label "hasObjectType" ;
+               skos:definition "Identifies the type of numismatic object. E.g. Coin, token, banknote."@en .
+
+
+###  http://nomisma.org/ontology#hasObverse
+:hasObverse rdf:type rdf:Property ;
+            rdfs:subPropertyOf :hasFace ;
+            rdfs:comment "Identifies a particular face of a numismatic object. Normally it will be the face carrying the represenation, badge or inscription of the issuing authority. In ancient, hand-struck coinage it is generally the lower (anvil) die. In English often known as \"heads\"."@en ;
+            rdfs:label "hasObverse" ;
+            skos:definition "Identifies a particular face of a numismatic object. Normally it will be the face carrying the represenation, badge or inscription of the issuing authority. In ancient, hand-struck coinage it is generally the lower (anvil) die. In English often known as \"heads\"."@en .
+
+
+###  http://nomisma.org/ontology#hasOpeningDate
+:hasOpeningDate rdf:type rdf:Property ;
+                rdfs:subPropertyOf :hasDate ;
+                rdfs:comment "The date of the earliest object (could be non-numismatic) of a given context, e.g. a hoard or layer."@en ;
+                rdfs:label "hasOpeningDate" ;
+                skos:definition "The date of the earliest object (could be non-numismatic) of a given context, e.g. a hoard or layer."@en .
+
+
+###  http://nomisma.org/ontology#hasPeculiarity
+:hasPeculiarity rdf:type rdf:Property ;
+                rdfs:comment "Describes a notable, characteristic or unusual physical feature of an individual numismatic object marks it out from other examples of the same group, or of a group of numismatic objects that marks it out from other groups. It can be the result of production, such as plating, or post-production activity, such as piercing, cutting or mounting."@en ;
+                rdfs:label "hasPeculiarity" ;
+                skos:definition "Describes a notable, characteristic or unusual physical feature of an individual numismatic object marks it out from other examples of the same group, or of a group of numismatic objects that marks it out from other groups. It can be the result of production, such as plating, or post-production activity, such as piercing, cutting or mounting."@en .
+
+
+###  http://nomisma.org/ontology#hasPeculiarityOfProduction
+:hasPeculiarityOfProduction rdf:type rdf:Property ;
+                            rdfs:subPropertyOf :hasPeculiarity ;
+                            rdfs:comment "Describes a notable, characteristic or unusual physical feature of an individual numismatic object which distinguishes it from other examples of the same group, or of a group of numismatic objects that marks it out from other groups, and which is related to the process of production of a numismatic object."@en ;
+                            rdfs:label "hasPeculiarityOfProduction" ;
+                            skos:definition "Describes a notable, characteristic or unusual physical feature of an individual numismatic object which distinguishes it from other examples of the same group, or of a group of numismatic objects that marks it out from other groups, and which is related to the process of production of a numismatic object."@en .
+
+
+###  http://nomisma.org/ontology#hasPortrait
+:hasPortrait rdf:type rdf:Property ;
+             rdfs:subPropertyOf :hasIconography ;
+             rdfs:label "hasPortrait" ;
+             skos:definition "Identifies the person whose portrait appears on a numismatic object."@en .
+
+
+###  http://nomisma.org/ontology#hasProductionDate
+:hasProductionDate rdf:type rdf:Property ;
+                   rdfs:subPropertyOf :hasDate ;
+                   rdfs:comment "Describes the date (range) of the production of a numismatic object."@en ;
+                   rdfs:label "hasProductionDate" ;
+                   skos:definition "Describes the date (range) of the production of a numismatic object."@en .
+
+
+###  http://nomisma.org/ontology#hasProductionObject
+:hasProductionObject rdf:type rdf:Property ;
+                     rdfs:comment "Objects used within the production process."@en ;
+                     rdfs:label "hasProductionObject" ;
+                     skos:definition "Objects used within the production process."@en .
+
+
+###  http://nomisma.org/ontology#hasReferenceWork
+:hasReferenceWork rdf:type rdf:Property ;
+                  rdfs:comment "Specifies a published work of reference relevant to a numismatic object."@en ;
+                  rdfs:label "hasReferenceWork" ;
+                  skos:definition "Specifies a published work of reference relevant to a numismatic object."@en .
+
+
+###  http://nomisma.org/ontology#hasReverse
+:hasReverse rdf:type rdf:Property ;
+            rdfs:subPropertyOf :hasFace ;
+            rdfs:comment "Identifies a the face of a numismatic object opposed to the obverse. In ancient, hand-struck coinage it is generally the upper die. In English often known as \"tails\"."@en ;
+            rdfs:label "hasReverse" ;
+            skos:definition "Identifies a the face of a numismatic object opposed to the obverse. In ancient, hand-struck coinage it is generally the upper die. In English often known as \"tails\"."@en .
+
+
+###  http://nomisma.org/ontology#hasScholarlyName
+:hasScholarlyName rdf:type rdf:Property ;
+                  rdfs:subPropertyOf dcterms:alternative ;
+                  rdfs:comment "A scholarly name is a term for a particular group of numismatic objects  or concept(s)  that was established after the time of their use, as part of scholarly jargon. Examples: Croeseid, Schneckentaler, Falkendukat, Antoninianus."@en ;
+                  rdfs:label "hasScholarlyName" ;
+                  skos:definition "A scholarly name is a term for a particular group of numismatic objects  or concept(s)  that was established after the time of their use, as part of scholarly jargon. Examples: Croeseid, Schneckentaler, Falkendukat, Antoninianus."@en .
+
+
+###  http://nomisma.org/ontology#hasSecondaryTreatment
+:hasSecondaryTreatment rdf:type rdf:Property ;
+                       rdfs:subPropertyOf :hasPeculiarity ;
+                       rdfs:comment "Describes anomalies or unusual features which arise subsequent to the actual production of a numismatic object; for example halving, chop-marking, etc."@en ;
+                       rdfs:label "hasSecondaryTreatment" ;
+                       skos:definition "Describes anomalies or unusual features which arise subsequent to the actual production of a numismatic object; for example halving, chop-marking, etc."@en .
+
+
+###  http://nomisma.org/ontology#hasShape
+:hasShape rdf:type rdf:Property ;
+          rdfs:subPropertyOf :hasAppearance ;
+          rdfs:comment "Describes the shape of a numismatic object."@en ;
+          rdfs:label "hasShape" ;
+          skos:definition "Describes the shape of a numismatic object."@en .
+
+
+###  http://nomisma.org/ontology#hasStartDate
+:hasStartDate rdf:type rdf:Property ;
+              rdfs:subPropertyOf :hasDate ;
+              rdfs:comment "Identifies the initial date in a range assigned in a numismatic context."@en ;
+              rdfs:label "hasStartDate" ;
+              skos:definition "Identifies the initial date in a range assigned in a numismatic context."@en .
+
+
+###  http://nomisma.org/ontology#hasStatedAuthority
+:hasStatedAuthority rdf:type rdf:Property ;
+                    rdfs:subPropertyOf :hasAppearance ;
+                    rdfs:comment "The authority as stated on a numismatic object. This may, but need not, be the same as the real authority behind the object (expressed separately as hasAuthority)."@en ;
+                    rdfs:label "hasStatedAuthority" ;
+                    skos:definition "The authority as stated on a numismatic object. This may, but need not, be the same as the real authority behind the object (expressed separately as hasAuthority)."@en .
+
+
+###  http://nomisma.org/ontology#hasTypeSeriesItem
+:hasTypeSeriesItem rdf:type rdf:Property ;
+                   rdfs:comment "Identifies the position of a numismatic object within a published or recognized reference list of types, such as a catalogue or corpus."@en ;
+                   rdfs:label "hasTypeSeriesItem" ;
+                   skos:definition "Identifies the position of a numismatic object within a published or recognized reference list of types, such as a catalogue or corpus."@en .
+
+
+###  http://nomisma.org/ontology#hasWear
+:hasWear rdf:type rdf:Property ;
+         rdfs:comment "Describes wear visible on a numismatic object due to use or circulation, commonly in terms prescribed by \"Abnutzung und Korrosion: Bestimmmungstafeln zur Bearbeitung von Fundmünzen = Usure et corrosion. (1995). Lausanne.\" (OCLC 174260520)"@en ;
+         rdfs:label "hasWear" ;
+         skos:definition "Describes wear visible on a numismatic object due to use or circulation, commonly in terms prescribed by \"Abnutzung und Korrosion: Bestimmmungstafeln zur Bearbeitung von Fundmünzen = Usure et corrosion. (1995). Lausanne.\" (OCLC 174260520)"@en .
+
+
+###  http://nomisma.org/ontology#hasWeight
+:hasWeight rdf:type rdf:Property ;
+           rdfs:subPropertyOf :hasMeasurement ;
+           rdfs:comment "Describes the actual weight of a numismatic object."@en ;
+           rdfs:label "hasWeight" ;
+           skos:definition "Describes the actual weight of a numismatic object."@en .
+
+
+###  http://nomisma.org/ontology#hasWeightStandard
+:hasWeightStandard rdf:type rdf:Property ;
+                   rdfs:comment "Describes the conventional weight system according to which a numismatic object of intrinsic value was produced."@en ;
+                   rdfs:label "hasWeightStandard" ;
+                   skos:definition "Describes the conventional weight system according to which a numismatic object of intrinsic value was produced."@en .
+
+
+###  http://nomisma.org/ontology#hasWidth
+:hasWidth rdf:type rdf:Property ;
+          rdfs:subPropertyOf :hasMeasurement ;
+          rdfs:comment "Describes the width of a numismatic object."@en ;
+          rdfs:label "hasWidth" ;
+          skos:definition "Describes the width of a numismatic object."@en .
+
+
+###  http://nomisma.org/ontology#isAbove
+:isAbove rdf:type rdf:Property ;
+         rdfs:subPropertyOf :hasFindContext ;
+         owl:inverseOf :isBelow ;
+         rdf:type owl:TransitiveProperty ;
+         rdfs:domain :StratigraphicUnit ;
+         rdfs:range :StratigraphicUnit ;
+         rdfs:comment "Based on the Harris Matrix system for units of archaeological stratification. The subject unit is above the object unit in the relative sequence of the units of stratification through time (see: Principles of archaeological stratigraphy by Edward Harris)."@en ;
+         rdfs:label "isAbove" ;
+         skos:definition "Based on the Harris Matrix system for units of archaeological stratification. The subject unit is above the object unit in the relative sequence of the units of stratification through time (see: Principles of archaeological stratigraphy by Edward Harris)."@en .
+
+
+###  http://nomisma.org/ontology#isBelow
+:isBelow rdf:type rdf:Property ;
+         rdfs:subPropertyOf :hasFindContext ;
+         rdf:type owl:TransitiveProperty ;
+         rdfs:domain :StratigraphicUnit ;
+         rdfs:range :StratigraphicUnit ;
+         rdfs:comment "Based on the Harris Matrix system for units of archaeological stratification. The subject unit is below the object in the relative sequence of the units of stratification through time (see: Principles of archaeological stratigraphy by Edward Harris)."@en ;
+         rdfs:label "isBelow"@en ;
+         skos:definition "Based on the Harris Matrix system for units of archaeological stratification. The subject unit is below the object in the relative sequence of the units of stratification through time (see: Principles of archaeological stratigraphy by Edward Harris)."@en .
+
+
+###  http://nomisma.org/ontology#isEqual
+:isEqual rdf:type rdf:Property ;
+         rdfs:subPropertyOf :hasFindContext ;
+         rdf:type owl:SymmetricProperty ;
+         rdfs:domain :StratigraphicUnit ;
+         rdfs:range :StratigraphicUnit ;
+         rdfs:comment "Based on the Harris Matrix system for units of archaeological stratification. The units are correlated (equated by the = sign) as separate parts (given different numbers in the field) of a once whole deposit or feature interface (see: Principles of archaeological stratigraphy by Edward Harris)."@en ;
+         rdfs:label "isEqual"@en ;
+         skos:definition "Based on the Harris Matrix system for units of archaeological stratification. The units are correlated (equated by the = sign) as separate parts (given different numbers in the field) of a once whole deposit or feature interface (see: Principles of archaeological stratigraphy by Edward Harris)."@en .
+
+
+###  http://nomisma.org/ontology#representsObjectType
+:representsObjectType rdf:type rdf:Property ;
+                      rdfs:comment "To indicate what kind of object type is represented by (for example) an type series item (a coin, banknote, token, ...)."@en ;
+                      rdfs:label "representsObjectType" ;
+                      skos:definition "To indicate what kind of object type is represented by (for example) an type series item (a coin, banknote, token, ...)."@en .
+
+
+###  http://nomisma.org/ontology#reproductionOf
+:reproductionOf rdf:type rdf:Property ;
+                rdfs:comment "Connects a reproduction of a numismatic object (to study it or to generate a surrogate – should not be used for contemporary imitations or forgeries) to its original."@en ;
+                rdfs:label "reproductionOf" ;
+                skos:definition "Connects a reproduction of a numismatic object (to study it or to generate a surrogate – should not be used for contemporary imitations or forgeries) to its original."@en .
+
+
+###  http://purl.org/dc/terms/alternative
+dcterms:alternative rdf:type rdf:Property .
+
+
+#################################################################
+#    Classes
+#################################################################
+
+###  http://nomisma.org/ontology#Authenticity
+:Authenticity rdf:type owl:Class ;
+              rdfs:comment "The contemporary legal status of a numismatic object: whether it was produced by an authority that had the relevant rights to do so, or is a contemporary or modern imitation."@en ;
+              rdfs:label "Authenticity" ;
+              skos:definition "The contemporary legal status of a numismatic object: whether it was produced by an authority that had the relevant rights to do so, or is a contemporary or modern imitation."@en .
+
+
+###  http://nomisma.org/ontology#CoinWear
+:CoinWear rdf:type owl:Class ;
+          rdfs:subClassOf :Wear .
+
+
+###  http://nomisma.org/ontology#Collection
+:Collection rdf:type owl:Class .
+
+
+###  http://nomisma.org/ontology#Context
+:Context rdf:type owl:Class ;
+         rdfs:comment "The archaeological context of a numismatic object."@en ;
+         rdfs:label "Context" ;
+         skos:definition "The archaeological context of a numismatic object. "@en .
+
+
+###  http://nomisma.org/ontology#Controlmark
+:Controlmark rdf:type owl:Class ;
+             rdfs:comment "A control mark is a letter, symbol or an inscription on a numismatic object intended to distinguish a group of coins within an issue or series."@en ;
+             rdfs:label "Controlmark" ;
+             skos:definition "A control mark is a letter, symbol or an inscription on a numismatic object intended to distinguish a group of coins within an issue or series."@en .
+
+
+###  http://nomisma.org/ontology#Corrosion
+:Corrosion rdf:type owl:Class ;
+           rdfs:comment "Degradation to a numismatic object due to chemical reaction with its environment."@en ;
+           rdfs:label "Corrosion" ;
+           skos:definition "Degradation to a numismatic object due to chemical reaction with its environment."@en .
+
+
+###  http://nomisma.org/ontology#Countermark
+:Countermark rdf:type owl:Class ;
+             rdfs:subClassOf :SecondaryTreatment ;
+             rdfs:comment "A mark or symbol punched into a coin or similar object at some point during its time in circulation."@en ;
+             rdfs:label "Countermark" ;
+             skos:definition "A mark or symbol punched into a coin or similar object at some point during its time in circulation."@en .
+
+
+###  http://nomisma.org/ontology#Denomination
+:Denomination rdf:type owl:Class .
+
+
+###  http://nomisma.org/ontology#DepositionType
+:DepositionType rdf:type owl:Class ;
+                rdfs:subClassOf :Context ;
+                rdfs:comment "The circumstances under which an object or group of objects came to be deposited and part of the archaeological record, for example as a hoard, votive deposit or chance loss."@en ;
+                rdfs:label "DepositionType" ;
+                skos:definition "The circumstances under which an object or group of objects came to be deposited and part of the archaeological record, for example as a hoard, votive deposit or chance loss."@en .
+
+
+###  http://nomisma.org/ontology#DieWear
+:DieWear rdf:type owl:Class ;
+         rdfs:subClassOf :Wear ;
+         rdfs:comment "Wear on a die occurring as a result of its use."@en ;
+         rdfs:label "DieWear" ;
+         skos:definition "Wear on a die occurring as a result of its use."@en .
+
+
+###  http://nomisma.org/ontology#DiscoveryType
+:DiscoveryType rdf:type owl:Class ;
+               rdfs:subClassOf :Context ;
+               rdfs:comment "The circumstances under which an object or group of objects came to be discovered, for example as a chance stray find or a controlled excavation."@en ;
+               rdfs:label "DiscoveryType" ;
+               skos:definition "The circumstances under which an object or group of objects came to be discovered, for example as a chance stray find or a controlled excavation."@en .
+
+
+###  http://nomisma.org/ontology#Ethnic
+:Ethnic rdf:type owl:Class .
+
+
+###  http://nomisma.org/ontology#FieldOfNumismatics
+:FieldOfNumismatics rdf:type owl:Class .
+
+
+###  http://nomisma.org/ontology#Find
+:Find rdf:type owl:Class ;
+      rdfs:subClassOf :Context ;
+      rdfs:comment "A numismatic object or group of numismatic objects that was lost or deposited, whether intentionally or unintentionally, in previous times, and subsequently recovered. The recovery takes place independently of any intention of retrieval associated with the original deposition."@en ;
+      rdfs:label "Find" ;
+      skos:definition "A numismatic object or group of numismatic objects that was lost or deposited, whether intentionally or unintentionally, in previous times, and subsequently recovered. The recovery takes place independently of any intention of retrieval associated with the original deposition."@en .
+
+
+###  http://nomisma.org/ontology#Hoard
+:Hoard rdf:type owl:Class ;
+       rdfs:subClassOf :Find ;
+       rdfs:comment "Within nomisma this is defined as a group of objects deposited together, of which at least one is a numismatic object."@en ;
+       rdfs:label "Hoard" ;
+       skos:definition "Within nomisma this is defined as a group of objects deposited together, of which at least one is a numismatic object."@en .
+
+
+###  http://nomisma.org/ontology#Manufacture
+:Manufacture rdf:type owl:Class .
+
+
+###  http://nomisma.org/ontology#Material
+:Material rdf:type owl:Class .
+
+
+###  http://nomisma.org/ontology#Mint
+:Mint rdf:type owl:Class .
+
+
+###  http://nomisma.org/ontology#Mintmark
+:Mintmark rdf:type owl:Class ;
+          rdfs:subClassOf :Controlmark ;
+          rdfs:comment "A mint mark is a letter, symbol or an inscription on a numismatic object indicating the mint where the numismatic object was produced."@en ;
+          rdfs:label "Mintmark" ;
+          skos:definition "A mint mark is a letter, symbol or an inscription on a numismatic object indicating the mint where the numismatic object was produced."@en .
+
+
+###  http://nomisma.org/ontology#Monogram
+:Monogram rdf:type owl:Class ;
+          rdfs:comment "A monogram is a symbol made by overlapping or combining of letters or other graphemes."@en ;
+          rdfs:label "Monogram" ;
+          skos:definition "A monogram is a symbol made by overlapping or combining of letters or other graphemes."@en .
+
+
+###  http://nomisma.org/ontology#NumismaticObject
+:NumismaticObject rdf:type owl:Class ;
+                  rdfs:comment "Objects considered to be within the numismatic domain such as coins, tokens, banknotes etc."@en ;
+                  rdfs:label "NumismaticObject" ;
+                  skos:definition "Objects considered to be within the numismatic domain such as coins, tokens, banknotes etc."@en .
+
+
+###  http://nomisma.org/ontology#NumismaticTerm
+:NumismaticTerm rdf:type owl:Class ;
+                rdfs:comment "A term used within the field of numismatics to describe or to otherwise convey information specific to the numismatic discipline, or to numismatic objects."@en ;
+                rdfs:label "NumismaticTerm" ;
+                skos:definition "A term used within the field of numismatics to describe or to otherwise convey information specific to the numismatic discipline, or to numismatic objects."@en .
+
+
+###  http://nomisma.org/ontology#ObjectType
+:ObjectType rdf:type owl:Class .
+
+
+###  http://nomisma.org/ontology#Peculiarity
+:Peculiarity rdf:type owl:Class ;
+             rdfs:comment "A notable, characteristic or unusual physical feature of an individual numismatic object that marks it out from other examples of the same group, or of a group of numismatic objects that marks it out from other groups."@en ;
+             rdfs:label "Peculiarity" ;
+             skos:definition "A notable, characteristic or unusual physical feature of an individual numismatic object that marks it out from other examples of the same group, or of a group of numismatic objects that marks it out from other groups."@en .
+
+
+###  http://nomisma.org/ontology#PeculiarityOfProduction
+:PeculiarityOfProduction rdf:type owl:Class ;
+                         rdfs:subClassOf :Peculiarity ;
+                         rdfs:comment "A notable, characteristic or unusual physical feature of an individual numismatic object which distinguishes it from other examples of the same group, or of a group of numismatic objects that marks it out from other groups, and which is related to the process of production of a numismatic object."@en ;
+                         rdfs:label "PeculiarityOfProduction" ;
+                         skos:definition "A notable, characteristic or unusual physical feature of an individual numismatic object which distinguishes it from other examples of the same group, or of a group of numismatic objects that marks it out from other groups, and which is related to the process of production of a numismatic object."@en .
+
+
+###  http://nomisma.org/ontology#ReferenceWork
+:ReferenceWork rdf:type owl:Class ;
+               rdfs:subClassOf dcterms:BibliographicResource .
+
+
+###  http://nomisma.org/ontology#Region
+:Region rdf:type owl:Class .
+
+
+###  http://nomisma.org/ontology#SecondaryTreatment
+:SecondaryTreatment rdf:type owl:Class ;
+                    rdfs:subClassOf :Peculiarity ;
+                    rdfs:comment "Anomalies or unusual features which arise subsequent to the actual production of a numismatic object; for example halving, chop-marking, etc."@en ;
+                    rdfs:label "SecondaryTreatment" ;
+                    skos:definition "Anomalies or unusual features which arise subsequent to the actual production of a numismatic object; for example halving, chop-marking, etc."@en .
+
+
+###  http://nomisma.org/ontology#Shape
+:Shape rdf:type owl:Class ;
+       rdfs:comment "The possible shapes numismatic objects might have, could be standard like round or rectangular or even a polygon."@en ;
+       rdfs:label "Shape" ;
+       skos:definition "The possible shapes numismatic objects might have, could be standard like round or rectangular or even a polygon."@en .
+
+
+###  http://nomisma.org/ontology#StratigraphicUnit
+:StratigraphicUnit rdf:type owl:Class ;
+                   rdfs:comment "A stratigraphic unit is a volume of identifiable origin and relative age range that is defined by the distinctive and dominant, easily mapped and recognizable features that characterize it."@en ;
+                   rdfs:label "StratigraphicUnit"@en ;
+                   skos:definition "A stratigraphic unit is a volume of identifiable origin and relative age range that is defined by the distinctive and dominant, easily mapped and recognizable features that characterize it."@en .
+
+
+###  http://nomisma.org/ontology#TypeSeries
+:TypeSeries rdf:type owl:Class ;
+            rdfs:subClassOf :ReferenceWork .
+
+
+###  http://nomisma.org/ontology#TypeSeriesItem
+:TypeSeriesItem rdf:type owl:Class .
+
+
+###  http://nomisma.org/ontology#Wear
+:Wear rdf:type owl:Class .
+
+
+###  http://nomisma.org/ontology#WeightStandard
+:WeightStandard rdf:type owl:Class ;
+                rdfs:subClassOf dcterms:Standard .
+
+
+###  http://purl.org/dc/terms/BibliographicResource
+dcterms:BibliographicResource rdf:type owl:Class .
+
+
+###  http://purl.org/dc/terms/Standard
+dcterms:Standard rdf:type owl:Class .
+
+
+#################################################################
+#    Individuals
+#################################################################
+
+###  http://nomisma.org/id/coin
+<http://nomisma.org/id/coin> rdf:type owl:NamedIndividual ;
+                             owl:sameAs :Coin .
+
+
+###  http://nomisma.org/ontology#Coin
+
+###  http://nomisma.org/id/coin_wear
+<http://nomisma.org/id/coin_wear> rdf:type owl:NamedIndividual ;
+                                  owl:sameAs :CoinWear .
+
+
+###  http://nomisma.org/ontology#CoinWear
+
+###  http://nomisma.org/id/collection
+<http://nomisma.org/id/collection> rdf:type owl:NamedIndividual ;
+                                   owl:sameAs :Collection .
+
+
+###  http://nomisma.org/ontology#Collection
+
+###  http://nomisma.org/id/denomination
+<http://nomisma.org/id/denomination> rdf:type owl:NamedIndividual ;
+                                     owl:sameAs :Denomination .
+
+
+###  http://nomisma.org/ontology#Denomination
+
+###  http://nomisma.org/id/ethnic
+<http://nomisma.org/id/ethnic> rdf:type owl:NamedIndividual ;
+                               owl:sameAs :Ethnic .
+
+
+###  http://nomisma.org/ontology#Ethnic
+
+###  http://nomisma.org/id/field_of_numismatics
+<http://nomisma.org/id/field_of_numismatics> rdf:type owl:NamedIndividual ;
+                                             owl:sameAs :FieldOfNumismatics .
+
+
+###  http://nomisma.org/ontology#FieldOfNumismatics
+
+###  http://nomisma.org/id/manufacture
+<http://nomisma.org/id/manufacture> rdf:type owl:NamedIndividual ;
+                                    owl:sameAs :Manufacture .
+
+
+###  http://nomisma.org/ontology#Manufacture
+
+###  http://nomisma.org/id/material
+<http://nomisma.org/id/material> rdf:type owl:NamedIndividual ;
+                                 owl:sameAs :Material .
+
+
+###  http://nomisma.org/ontology#Material
+
+###  http://nomisma.org/id/medal
+<http://nomisma.org/id/medal> rdf:type owl:NamedIndividual ;
+                              owl:sameAs :Medal .
+
+
+###  http://nomisma.org/ontology#Medal
+
+###  http://nomisma.org/id/mint
+<http://nomisma.org/id/mint> rdf:type owl:NamedIndividual ;
+                             owl:sameAs :Mint .
+
+
+###  http://nomisma.org/ontology#Mint
+
+###  http://nomisma.org/id/object_type
+<http://nomisma.org/id/object_type> rdf:type owl:NamedIndividual ;
+                                    owl:sameAs :ObjectType .
+
+
+###  http://nomisma.org/ontology#ObjectType
+
+###  http://nomisma.org/id/reference_work
+<http://nomisma.org/id/reference_work> rdf:type owl:NamedIndividual ;
+                                       owl:sameAs :ReferenceWork .
+
+
+###  http://nomisma.org/ontology#ReferenceWork
+
+###  http://nomisma.org/id/region
+<http://nomisma.org/id/region> rdf:type owl:NamedIndividual ;
+                               owl:sameAs :Region .
+
+
+###  http://nomisma.org/ontology#Region
+
+###  http://nomisma.org/id/seal
+<http://nomisma.org/id/seal> rdf:type owl:NamedIndividual ;
+                             owl:sameAs :Seal .
+
+
+###  http://nomisma.org/ontology#Seal
+
+###  http://nomisma.org/id/type_series
+<http://nomisma.org/id/type_series> rdf:type owl:NamedIndividual ;
+                                    owl:sameAs :TypeSeries .
+
+
+###  http://nomisma.org/ontology#TypeSeries
+
+###  http://nomisma.org/id/type_series_item
+<http://nomisma.org/id/type_series_item> rdf:type owl:NamedIndividual ;
+                                         owl:sameAs :TypeSeriesItem .
+
+
+###  http://nomisma.org/ontology#TypeSeriesItem
+
+###  http://nomisma.org/id/weight_standard
+<http://nomisma.org/id/weight_standard> rdf:type owl:NamedIndividual ;
+                                        owl:sameAs :WeightStandard .
+
+
+###  http://nomisma.org/ontology#WeightStandard
+
+###  http://nomisma.org/ontology#Coin
+:Coin rdf:type owl:NamedIndividual .
+
+
+###  http://nomisma.org/ontology#CoinWear
+:CoinWear rdf:type owl:NamedIndividual .
+
+
+###  http://nomisma.org/ontology#Collection
+:Collection rdf:type owl:NamedIndividual .
+
+
+###  http://nomisma.org/ontology#Denomination
+:Denomination rdf:type owl:NamedIndividual .
+
+
+###  http://nomisma.org/ontology#Ethnic
+:Ethnic rdf:type owl:NamedIndividual .
+
+
+###  http://nomisma.org/ontology#FieldOfNumismatics
+:FieldOfNumismatics rdf:type owl:NamedIndividual .
+
+
+###  http://nomisma.org/ontology#Manufacture
+:Manufacture rdf:type owl:NamedIndividual .
+
+
+###  http://nomisma.org/ontology#Material
+:Material rdf:type owl:NamedIndividual .
+
+
+###  http://nomisma.org/ontology#Medal
+:Medal rdf:type owl:NamedIndividual .
+
+
+###  http://nomisma.org/ontology#Medallion
+:Medallion rdf:type owl:NamedIndividual .
+
+
+###  http://nomisma.org/ontology#Mint
+:Mint rdf:type owl:NamedIndividual .
+
+
+###  http://nomisma.org/ontology#ObjectType
+:ObjectType rdf:type owl:NamedIndividual .
+
+
+###  http://nomisma.org/ontology#ReferenceWork
+:ReferenceWork rdf:type owl:NamedIndividual .
+
+
+###  http://nomisma.org/ontology#Region
+:Region rdf:type owl:NamedIndividual .
+
+
+###  http://nomisma.org/ontology#Seal
+:Seal rdf:type owl:NamedIndividual .
+
+
+###  http://nomisma.org/ontology#Tessera
+:Tessera rdf:type owl:NamedIndividual .
+
+
+###  http://nomisma.org/ontology#Token
+:Token rdf:type owl:NamedIndividual .
+
+
+###  http://nomisma.org/ontology#TypeSeries
+:TypeSeries rdf:type owl:NamedIndividual .
+
+
+###  http://nomisma.org/ontology#TypeSeriesItem
+:TypeSeriesItem rdf:type owl:NamedIndividual .
+
+
+###  http://nomisma.org/ontology#Wear
+:Wear rdf:type owl:NamedIndividual .
+
+
+###  http://nomisma.org/ontology#WeightStandard
+:WeightStandard rdf:type owl:NamedIndividual .
+
+
+#################################################################
+#    Annotations
+#################################################################
+
+:CoinWear rdfs:comment "Wear on a coin or similar objects occurring as a result of its use."@en ;
+          rdfs:label "CoinWear" ;
+          skos:definition "Wear on a coin or similar objects occurring as a result of its use."@en .
+
+
+:Collection rdfs:comment "General term meaning the objects held by an institution or individual. Or the holding entity itself."@en ;
+            rdfs:label "Collection" ;
+            skos:definition "General term meaning the objects held by an institution or individual. Or the holding entity itself."@en .
+
+
+:Denomination rdfs:comment "Term indicating the value of a numismatic object. Examples: tetradrachm, chalkous, denarius."@en ;
+              rdfs:label "Denomination" ;
+              skos:definition "Term indicating the value of a numismatic object. Examples: tetradrachm, chalkous, denarius."@en .
+
+
+:Ethnic rdfs:comment "Generally, a tribal or ethnic name appearing on a numismatic object. Distinct from personal authority as indicated by the presence of ruler's name."@en ;
+        rdfs:label "Ethnic" ;
+        skos:definition "Generally, a tribal or ethnic name appearing on a numismatic object. Distinct from personal authority as indicated by the presence of ruler's name."@en .
+
+
+:FieldOfNumismatics rdfs:comment "Any widely recognized area of study within the discipline of numismatics."@en ;
+                    rdfs:label "FieldOfNumismatics" ;
+                    skos:definition "Any widely recognized area of study within the discipline of numismatics."@en .
+
+
+:Manufacture rdfs:comment "The technique of manufacture. For example, struck or cast."@en ;
+             rdfs:label "Manufacture" ;
+             skos:definition "The technique of manufacture. For example, struck or cast."@en .
+
+
+:Material rdfs:comment "The physical material from which an object is made."@en ;
+          rdfs:label "Material" ;
+          skos:definition "The physical material from which an object is made."@en .
+
+
+:Mint rdfs:comment "Generic term for a place of manufacture of a numismatic object or for the issuing city."@en ;
+      rdfs:label "Mint" ;
+      skos:definition "Generic term for a place of manufacture of a numismatic object or for the issuing city."@en .
+
+
+:ObjectType rdfs:comment "The numismatic type of an object. Ex. 'coin'."@en ;
+            rdfs:label "ObjectType" ;
+            skos:definition "The numismatic type of an object. Ex. 'coin'."@en .
+
+
+:ReferenceWork rdfs:comment "A published work of reference relevant to a numismatic object."@en ;
+               rdfs:label "ReferenceWork" ;
+               skos:definition "A published work of reference relevant to a numismatic object."@en .
+
+
+:Region rdfs:comment "An area of geographic significance and/or taxonomic importance, perhaps part of a larger geographic/administrative unit, having definable characteristics but not always fixed boundaries."@en ;
+        rdfs:label "Region" ;
+        skos:definition "An area of geographic significance and/or taxonomic importance, perhaps part of a larger geographic/administrative unit, having definable characteristics but not always fixed boundaries."@en .
+
+
+:TypeSeries rdfs:comment "A published or recognized reference list of numismatic object types, such as a catalogue or corpus."@en ;
+            rdfs:label "TypeSeries" ;
+            skos:definition "A published or recognized reference list of numismatic object types, such as a catalogue or corpus."@en .
+
+
+:TypeSeriesItem rdfs:comment "An item within a reference list of numismatic object types."@en ;
+                rdfs:label "TypeSeriesItem" ;
+                skos:definition "An item within a reference list of numismatic object types."@en .
+
+
+:Wear rdfs:comment "Wear on a numismatic object occurring as a result of its use."@en ;
+      rdfs:label "Wear" ;
+      skos:definition "Wear on a numismatic object occurring as a result of its use."@en .
+
+
+:WeightStandard rdfs:comment "The conventional weight system according to which a numismatic object was produced."@en ;
+                rdfs:label "WeightStandard" ;
+                skos:definition "The conventional weight system according to which a numismatic object was produced."@en .
+
+
+###  Generated by the OWL API (version 4.5.29.2024-05-13T12:11:03Z) https://github.com/owlcs/owlapi


### PR DESCRIPTION
Based on Nomisma Call  5th February 2025
changes:
changed from owl:ObjectProperty to rdf:Property
nmo:hasFindsport as supPropertyOf (sPO) nmo:hasFindContext nmo:hasEndDate and nmo:hasStartDate as sPO nmo:hasDate nmo:hasStatedAuthority as sPO nmo:Appearance
nmo:isAbove, nmo:isBelow, nmo:isEqual as sPO of nmo:hasContext nmo:hasControlmark as sPO nmo:hasMark
new:
nmo:hasMeasurement as SuperProperty for: nmo:hasDiameter, nmo:hasDepth, nmo:hasWidth, nmo:hasHeight, nmo:hasWeight (just for a better structuring)